### PR TITLE
Add option to delete the old indexing data from the prod ES server

### DIFF
--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -19,8 +19,8 @@ jobs:
       - name: rsync production snapshot to sanger lustre
         run: |
           rsync -av --delete /volumes/docker/snapshots/production/production-${{ inputs.release }} farm:/lustre/scratch123/tol/share/goat/dev/
-          rsync -av --delete /volumes/docker/resources/files/                         farm:/lustre/scratch123/tol/share/goat/dev/files/
-          /home/ubuntu/scripts/clean_goat_data.sh -d /volumes/docker/snapshots/production -r
+          rsync -av --delete /volumes/docker/resources/files/ farm:/lustre/scratch123/tol/share/goat/dev/files/
+          /home/ubuntu/scripts/clean_goat_data.sh -d /volumes/docker/snapshots/production -r -p
           ssh farm /software/treeoflife/bin/clean_goat_data.sh -d /lustre/scratch123/tol/share/goat/dev -m  -r
  
   restore-on-prod:

--- a/scripts/clean_goat_data.sh
+++ b/scripts/clean_goat_data.sh
@@ -5,12 +5,13 @@
 # The script will keep the data directories that are within the days to keep
 # The script will keep the data directories that are the first data of the month if keep_first_data_of_month is enabled
 # The script will delete the data directories that are not in the list of data to keep 
+# The script will delete the ES index for the data directories that are deleted if remove_prod_es_index is enabled
 
 set -e
 set -o pipefail
 
 usage() {
-    echo "Usage: $0 [-r] [-m] [-d <goat_data_dir>] [-k <days_to_keep>] " >&2
+    echo "Usage: $0 [-r] [-m] [-d <goat_data_dir>] [-k <days_to_keep>] [-p] " >&2
     exit 1
 }
 

--- a/scripts/clean_goat_data.sh
+++ b/scripts/clean_goat_data.sh
@@ -15,13 +15,15 @@ usage() {
 }
 
 GOAT_ARCHIVED_LIST_FILE="goat_archived_list.txt"
+GOAT_PROD_VM="tol-goat-prod-run1"
 goat_data_dir=''
 days_to_keep=3
 keep_first_data_of_month=false
 dry_run=true
+remove_prod_es_index=false
 goat_archived_list=()
 
-while getopts ':rmd:k:' opt; do
+while getopts ':rmd:k:p' opt; do
     case "$opt" in
         r)
             dry_run=false
@@ -34,6 +36,9 @@ while getopts ':rmd:k:' opt; do
             ;;
         k)
             days_to_keep="$OPTARG"
+            ;;
+        p)
+            remove_prod_es_index=true
             ;;
         :)
             echo "Option -$OPTARG requires an argument." >&2
@@ -141,9 +146,16 @@ echo "================"
 count_deleted=0
 for day_data_dir in `ls -d production-202[0-9].[0-1][0-9].[0-3][0-9]`; do
     if [[ ! " ${data_dir_to_keep[@]} " =~ " ${day_data_dir} " ]]; then
+        echo "================"
         echo "Delete data directory ${day_data_dir}"
         $cmd rm -rf $day_data_dir
         count_deleted=$((count_deleted+1))
+        
+        if $remove_prod_es_index; then
+            echo "Delete ES index for ${day_data_dir}"
+            day=${day_data_dir#"production-"}
+            $cmd ssh $GOAT_PROD_VM "curl -X DELETE es1:9200/*-${day}"
+        fi
     fi
 done
 


### PR DESCRIPTION
I have updated the script on the VM to delete the old index data on ES server. 

The only problem is that the index data list is based on the data on the disk not on the ES server.

If you manually delete the data on disk, you also need to delete the data on ES server.

I could do another query `curl -s  'es1:9200/_cat/indices?v'` but for now it should be fine.

I have manually clean the old data on ES server and currently only 8 days left there:
```
curl -s  'es1:9200/_cat/indices?v' | grep taxon--ncbi--goat--
yellow open   taxon--ncbi--goat--2024.09.09       eIxzlkQnTd-XsPoz3pFgLA   1   1   73448790     42463389      8.8gb          8.8gb
yellow open   taxon--ncbi--goat--2024.09.11       hlc1f5wdTfCTIfvoMfifcw   1   1   73451670     18646576      6.9gb          6.9gb
yellow open   taxon--ncbi--goat--2024.09.10       1xCfpTmmRbe5kTn7gKvMQw   1   1   73451448     16923937      6.8gb          6.8gb
yellow open   taxon--ncbi--goat--2022.11.16       Q_t44Eh_SlOe0hw9SsgQTg   1   1   69752556     18051898      6.2gb          6.2gb
yellow open   taxon--ncbi--goat--2023.02.20       vZgaVtN0TVuu1BZHxxYEmw   1   1   70610198     19286743      6.4gb          6.4gb
yellow open   taxon--ncbi--goat--2023.05.18       dKraRHIfTCWw6z-7MiCT_Q   1   1   71489417     16561045      6.3gb          6.3gb
yellow open   taxon--ncbi--goat--2023.10.16       Nir8Mv_BS8iTAu0chfqaqw   1   1   69163659     42111975      8.5gb          8.5gb
yellow open   taxon--ncbi--goat--2024.03.01       f3-6eeEHStO7Kn8PmAXQtg   1   1   68210681     24805816        7gb            7gb
```

This is the output from the clean_data script:

```
================
Checking done, in total 9!
The number of data dir to keep: 8
production-2024.09.11
production-2024.09.10
production-2024.09.09
production-2024.03.01
production-2023.10.16
production-2023.05.18
production-2023.02.20
production-2022.11.16
================
================
Delete data directory production-2024.01.20
Delete ES index for production-2024.01.20
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    21  100    21   {"acknowledged":true} 0     0  15086      0 --:--:-- --:--:-- --:--:-- 21000
================
In total 1 data directories are deleted!
```
