### PR TITLE
Add chordates and protists to fetch DTOL collections script

### DIFF
--- a/scripts/ebp_import/canbp_live_lims_sheet_curation.py
+++ b/scripts/ebp_import/canbp_live_lims_sheet_curation.py
@@ -77,4 +77,4 @@ def expand_sequencing_status(project_table, acronym):
 # Apply the new functions to the CANBP list and exprot the table
 create_status_column(canbp_list, "CANBP")
 expand_sequencing_status(canbp_list, "CANBP")
-canbp_list.to_csv("CANBP_status_expanded.tsv", sep="\t", index=False)
+canbp_list.to_csv("CANBP_livestatus_expanded.tsv", sep="\t", index=False)

--- a/scripts/ebp_import/get_tol_collected.py
+++ b/scripts/ebp_import/get_tol_collected.py
@@ -80,6 +80,20 @@ isl.export_expanded_tsv(DTOL_Fungi, "DTOL_Fungi_collected")
 #####
 #DTOL Protists
 
+dtol_protist = isl.open_google_spreadsheet("DTOL","https://docs.google.com/spreadsheets/d/e/2PACX-1vQOZv_it6Wa1i3l54sZgMR2w38Me_Zlbmfq81YlGEhKHmOX5HYg213yn1-97Py_qA/pub?gid=1818735230&single=true&output=tsv",0)
+dtol_protist = isl.cleanup_headers_specific_units(dtol_protist)
+dtol_protist = isl.general_cleanup_for_table(dtol_protist)
+
+prot_status_to_map = {
+    'COLLECTED': 'sample_collected',
+    'SUBMITTED':'sample_collected',
+    'RESUBMITTED':'sample_collected',
+    'GROWING':'sample_collected',
+    'DEAD': ""
+}
+dtol_protist['sample_collected'] = dtol_protist['status'].map(prot_status_to_map)
+isl.export_expanded_tsv(dtol_protist, "DTOL_protist_collected")
+
 #####
 #DTOL Chordata
 # https://docs.google.com/spreadsheets/d/1on84bBNxuUG5jouh4tb7clb5EQ2bvU5Z-o_wFyJg9VA/edit?gid=1707413927#gid=1707413927

--- a/scripts/ebp_import/get_tol_collected.py
+++ b/scripts/ebp_import/get_tol_collected.py
@@ -11,7 +11,7 @@ import numpy as np
 # DToL live sheet as of Nov 2024:
 # https://docs.google.com/spreadsheets/d/10-RSLWo-0Hn0Lx3z_WJYuvx0WcgrlokFhqUpq4byJEc/edit?pli=1#gid=1370114100
 # public tsv:
-#https://docs.google.com/spreadsheets/d/e/2PACX-1vR6BXo-Z8cGMoMuREw4qt1rIqwf1wY4rRlfPw2ehKspPe_l8Gn5xb6rHwZOp26FgThBaszDyarKhHfi/pub?gid=1370114100&single=true&output=tsv
+# https://docs.google.com/spreadsheets/d/e/2PACX-1vR6BXo-Z8cGMoMuREw4qt1rIqwf1wY4rRlfPw2ehKspPe_l8Gn5xb6rHwZOp26FgThBaszDyarKhHfi/pub?gid=1370114100&single=true&output=tsv
 
 #### Open dataframe and add file-specific edits to clean file contents
 DTOL_AFR = isl.open_google_spreadsheet("DTOL","https://docs.google.com/spreadsheets/d/e/2PACX-1vR6BXo-Z8cGMoMuREw4qt1rIqwf1wY4rRlfPw2ehKspPe_l8Gn5xb6rHwZOp26FgThBaszDyarKhHfi/pub?gid=1370114100&single=true&output=tsv",0)
@@ -76,11 +76,21 @@ DTOL_Fungi = isl.cleanup_headers_specific_units(DTOL_Fungi)
 # Export edited tsvs
 isl.export_expanded_tsv(DTOL_Fungi, "DTOL_Fungi_collected")
 
+
 #####
 #DTOL Protists
 
 #####
 #DTOL Chordata
+# https://docs.google.com/spreadsheets/d/1on84bBNxuUG5jouh4tb7clb5EQ2bvU5Z-o_wFyJg9VA/edit?gid=1707413927#gid=1707413927
+# published tsv: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vR35J07MSypi_jSOgX9Jxe7RIAo56NiI12esouj9jccdvjNxPV1-Hg5Idfk_1Zb0kQgiYrzNAC7Qjz3/pub?gid=1707413927&single=true&output=tsv'
+
+chordate_collected = isl.open_google_spreadsheet("DTOL","https://docs.google.com/spreadsheets/d/e/2PACX-1vR35J07MSypi_jSOgX9Jxe7RIAo56NiI12esouj9jccdvjNxPV1-Hg5Idfk_1Zb0kQgiYrzNAC7Qjz3/pub?gid=1707413927&single=true&output=tsv",0)
+chordate_collected = isl.general_cleanup_for_table(chordate_collected)
+chordate_collected = isl.cleanup_headers_specific_units(chordate_collected)
+
+isl.export_expanded_tsv(chordate_collected, "DTOL_chordata_collected")
+
 
 #####
 #PSYCHE

--- a/scripts/import_status_lib.py
+++ b/scripts/import_status_lib.py
@@ -176,6 +176,8 @@ def create_mandatory_columns(project_table):
         "synonym",
         "publication_id",
         "contributing_project_lab",
+        "target_list_status",
+        "sequencing_status",
     ]
     for item in mandatory_fields:
         if item not in project_table:


### PR DESCRIPTION
This is manually run once a week to retrieve DToL collected from Samples Working Groups files and Project Psyche collections tracker. It will require paths before adding it to the goat-data fetch workflow.