### PR TITLE
change STS script

### DIFF
--- a/scripts/api/api_config.py
+++ b/scripts/api/api_config.py
@@ -163,7 +163,7 @@ sts_fieldnames = [
 
 
 def sts_url_opener(token):
-    return requests.get(sts_url, headers={"Authorization": token, "Project": "ALL"},verify=False)
+    return requests.get(sts_url, headers={"Token": token, "Project": "ALL"},verify=False)
 
 
 def sts_api_count_handler(r_text):


### PR DESCRIPTION
header is now "Token" not "Authorization" to bring it in to line with all our other systems (TOL-P)

## Summary by Sourcery

Enhancements:
- The STS script now uses 'Token' instead of 'Authorization' in the header for consistency with other systems.