### PR TITLE
suppress RuntimeError

### DIFF
--- a/pipelines/assembly/parse_ncbi_assemblies.py
+++ b/pipelines/assembly/parse_ncbi_assemblies.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+import contextlib
 from collections import defaultdict
 from collections.abc import Generator
 from typing import Optional
@@ -76,13 +77,15 @@ def fetch_ncbi_datasets_summary(root_taxid: str):
             root_taxid,
             "--as-json-lines",
         ]
-        result = subprocess.run(command, capture_output=True, text=True)
-        if result.returncode != 0:
-            raise RuntimeError(f"Error fetching datasets summary: {result.stderr}")
-        for line in result.stdout.split("\n"):
-            if not line:
-                continue
-            yield am.convert_keys_to_camel_case(json.loads(line))
+        with contextlib.suppress(RuntimeError):
+            result = subprocess.run(command, capture_output=True, text=True)
+            if result.returncode != 0:
+                print(f"Error fetching datasets summary: {result.stderr}")
+                raise RuntimeError(f"Error fetching datasets summary: {result.stderr}")
+            for line in result.stdout.split("\n"):
+                if not line:
+                    continue
+                yield am.convert_keys_to_camel_case(json.loads(line))
 
 
 def fetch_ncbi_datasets_sequences(

--- a/pipelines/assembly/parse_ncbi_assemblies.py
+++ b/pipelines/assembly/parse_ncbi_assemblies.py
@@ -5,7 +5,6 @@ import json
 import os
 import subprocess
 import sys
-import contextlib
 from collections import defaultdict
 from collections.abc import Generator
 from typing import Optional
@@ -44,7 +43,7 @@ def load_config(config_file: str, feature_file: Optional[str] = None):
 
 def fetch_ncbi_datasets_summary(root_taxid: str):
     taxids = [root_taxid]
-    if taxids == "2759":
+    if root_taxid == "2759":
         taxids = [
             "2763",
             "33090",
@@ -74,18 +73,17 @@ def fetch_ncbi_datasets_summary(root_taxid: str):
             "summary",
             "genome",
             "taxon",
-            root_taxid,
+            taxid,
             "--as-json-lines",
         ]
-        with contextlib.suppress(RuntimeError):
-            result = subprocess.run(command, capture_output=True, text=True)
-            if result.returncode != 0:
-                print(f"Error fetching datasets summary: {result.stderr}")
-                raise RuntimeError(f"Error fetching datasets summary: {result.stderr}")
-            for line in result.stdout.split("\n"):
-                if not line:
-                    continue
-                yield am.convert_keys_to_camel_case(json.loads(line))
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"Error fetching datasets summary: {result.stderr}")
+            continue
+        for line in result.stdout.split("\n"):
+            if not line:
+                continue
+            yield am.convert_keys_to_camel_case(json.loads(line))
 
 
 def fetch_ncbi_datasets_sequences(


### PR DESCRIPTION
Continue genome summary fetching after raised error for taxids without assemblies.

Added line to print raised error for now

## Summary by Sourcery

Make NCBI dataset summary fetching resilient to errors for individual taxids.

Bug Fixes:
- Prevent `fetch_ncbi_datasets_summary` from crashing if the `datasets` command fails for a specific taxid.
- Print the error message from the `datasets` command to stderr when it fails.