### PR TITLE
fix KeyError when taxid not present in row

### DIFF
--- a/pipelines/assembly/parse_ncbi_assemblies.py
+++ b/pipelines/assembly/parse_ncbi_assemblies.py
@@ -319,6 +319,7 @@ def filter_excess_assemblies(parsed: dict, taxon_id: str, threshold: int):
 
     def is_below_threshold(row):
         return (
+            "taxid" in row and
             row["taxid"] == taxon_id
             and row["assemblySpan"] is not None
             and row["assemblySpan"] < threshold


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent KeyError by checking if 'taxid' exists in the row before accessing it