### PR TITLE
Disable lustre backup and data clean

### DIFF
--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: rsync production snapshot to sanger lustre
         run: |
-          rsync -av --delete /volumes/docker/snapshots/production/production-${{ inputs.release }} farm:/lustre/scratch123/tol/share/goat/dev/
-          rsync -av --delete /volumes/docker/resources/files/ farm:/lustre/scratch123/tol/share/goat/dev/files/
+          # rsync -av --delete /volumes/docker/snapshots/production/production-${{ inputs.release }} farm:/lustre/scratch123/tol/share/goat/dev/
+          # rsync -av --delete /volumes/docker/resources/files/ farm:/lustre/scratch123/tol/share/goat/dev/files/
           /home/ubuntu/scripts/clean_goat_data.sh -d /volumes/docker/snapshots/production -r -p
-          ssh farm /software/treeoflife/bin/clean_goat_data.sh -d /lustre/scratch123/tol/share/goat/dev -m  -r
+          # ssh farm /software/treeoflife/bin/clean_goat_data.sh -d /lustre/scratch123/tol/share/goat/dev -m  -r
  
   restore-on-prod:
     runs-on: [self-hosted, runner2]


### PR DESCRIPTION
Comment out lustre backup and data clean steps, only leave the VM's data cleaning.

We have lost all the backup data on lustre. We can find another location if we still want to backup to somewhere else.

## Summary by Sourcery

Disable Lustre backup and remote data cleaning in the finish-release workflow, leaving only the local VM data cleaning step.

Chores:
- Comment out rsync steps for production snapshots and resource files to Lustre.
- Comment out remote clean_goat_data.sh invocation on Lustre.