### PR TITLE
Add AEGIS acronym to target and status ATTR constraints

### DIFF
--- a/sources/status-lists/ATTR_status_lists.types.yaml
+++ b/sources/status-lists/ATTR_status_lists.types.yaml
@@ -9,6 +9,7 @@ defaults:
     constraint:
       enum:
         - 1000gch
+        - aegis
         - africabp
         - ag100pest
         - agc
@@ -74,6 +75,8 @@ defaults:
         link: https://goat.genomehubs.org/projects/{}
       1000gch:
         description: "1,000 Chilean Genomes (click to view GoaT project page)"
+      aegis:
+        description: "Ancient Environmental Genomics Initiative for Sustainability (click to view GoaT project page)"
       africabp:
         description: "Africa Biogenome Project (click to view GoaT project page)"
       ag100pest:

--- a/sources/status-lists/ATTR_target_lists.types.yaml
+++ b/sources/status-lists/ATTR_target_lists.types.yaml
@@ -9,6 +9,7 @@ defaults:
     constraint:
       enum:
         - 1000gch
+        - aegis
         - africabp
         - ag100pest
         - agc
@@ -74,6 +75,8 @@ defaults:
         link: https://goat.genomehubs.org/projects/{}
       1000gch:
         description: "1,000 Chilean Genomes (click to view GoaT project page)"
+      aegis:
+        description: "Ancient Environmental Genomics Initiative for Sustainability (click to view GoaT project page)"
       africabp:
         description: "Africa Biogenome Project (click to view GoaT project page)"
       ag100pest:


### PR DESCRIPTION
Adding to [#128](https://github.com/genomehubs/goat-data/issues/128)

## Summary by Sourcery

Add AEGIS to the ATTR status and target constraint enums and include its descriptive text

New Features:
- Support AEGIS as a valid value in ATTR status constraint enums
- Support AEGIS as a valid value in ATTR target constraint enums

Documentation:
- Add descriptive entry for AEGIS in status lists
- Add descriptive entry for AEGIS in target lists