### PR TITLE
Add summary and type settings to assembly - taxon attributes

### DIFF
--- a/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
+++ b/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
@@ -27,12 +27,13 @@ attributes:
       PRJNA489245: BAT1K
       PRJNA923301: BEENOME100
       PRJNA1075696: BIOPLATFORMS
+      PRJNA707235: CAL-EBP
       PRJNA813333: CANBP
       PRJNA706690: CANSEQ150
       PRJEB49670: CBP
       PRJNA720569: CCGP
       PRJNA1020146: CGP
-      PRJNA1157211: DGB
+      PRJNA1157211: DBG
       PRJEB40665: DTOL
       PRJNA512907: DNAZOO
       PRJEB65317: EBPN
@@ -46,8 +47,9 @@ attributes:
       PRJNA1098046: FFI
       PRJNA1098053: FISH
       PRJNA1075727: GAP
-      PRJNA649812: GIGA
+      PRJNA1180976: GBB
       PRJNA1075702: GBR
+      PRJNA649812: GIGA
       PRJNA163993: i5K
       PRJNA844590: ILEBP
       PRJNA1098055: IPM
@@ -84,25 +86,29 @@ attributes:
       PRJNA489245: BAT1K
       PRJNA923301: BEENOME100
       PRJNA1075696: BIOPLATFORMS
+      PRJNA707235: CAL-EBP
       PRJNA813333: CANBP
       PRJNA706690: CANSEQ150
       PRJEB49670: CBP
       PRJNA720569: CCGP
       PRJNA1020146: CGP
-      PRJNA1157211: DGB
+      PRJNA1157211: DBG
       PRJEB40665: DTOL
       PRJNA512907: DNAZOO
       PRJEB65317: EBPN
       PRJNA712951: ENDEMIXIT
       PRJEB43510: ERGA
-      PRJEB66264: ERGA-COM
+      PRJEB61747: ERGA-BGE
+      PRJEB49197: ERGA-CH
       PRJEB47820: ERGA-PIL
+      PRJEB66264: ERGA-COM
       PRJNA393850: EUROFISH
       PRJNA1098046: FFI
       PRJNA1098053: FISH
       PRJNA1075727: GAP
-      PRJNA649812: GIGA
+      PRJNA1180976: GBB
       PRJNA1075702: GBR
+      PRJNA649812: GIGA
       PRJNA163993: i5K
       PRJNA844590: ILEBP
       PRJNA1098055: IPM
@@ -481,42 +487,15 @@ attributes:
 file:
   format: tsv
   header: true
-  name: ncbi_datasets_eukaryota.tsv.gz
-  organelle: nucleus
+  name: ncbi_datasets_eukaryota_taxon.tsv.gz
   source: INSDC
   source_url_stub: https://www.ncbi.nlm.nih.gov/assembly/
   source_date: "2025-06-10"
-identifiers:
-  assembly_id:
-    constraint:
-      len: 32
-    header: genbankAssmAccession
-    type: keyword
-  assembly_name:
-    constraint:
-      len: 64
-    header: assemblyName
-    type: keyword
-  genbank_accession:
-    constraint:
-      len: 32
-    header: genbankAssmAccession
-    type: keyword
-  refseq_accession:
-    constraint:
-      len: 32
-    header: refseqAssmAccession
-    type: keyword
-  wgs_accession:
-    constraint:
-      len: 16
-    header: wgsProjectAccession
-    type: keyword
 metadata:
   is_primary_value:
     header: primaryValue
-  source_slug:
-    header: genbankAssmAccession
+  # source_slug:
+  #   header: genbankAccession
 names:
   common_name:
     header: commonName

--- a/sources/assembly-data/ATTR_assembly.types.yaml
+++ b/sources/assembly-data/ATTR_assembly.types.yaml
@@ -49,34 +49,56 @@ attributes:
         link: https://www.ebi.ac.uk/ena/browser/view/{}
       prjna533106:
         description: "Earth Biogenome Project (click to view on ENA)"
+      prjeb33226:
+        description: "25 Genomes Project (click to view on ENA)"
+      prjeb80366:
+        description: "Ancient Environmental Genomics Initiative for Sustainability (click to view on ENA)"
       prjna811786:
         description: "Africa Biogenome Project (click to view on ENA)"
       prjna555319:
         description: "Ag100Pest (click to view on ENA)"
+      prjeb51690:
+        description: "Anopheles Reference Genomes Project (click to view on ENA)"
       prjeb43743:
         description: "Aquatic Symbiosis Genomics Project (click to view on ENA)"
+      prjeb64126:
+        description: "ATLASea (click to view on ENA)"
       prjna489245:
         description: "Bat 1K (click to view on ENA)"
+      prjna923301:
+        description: "The Beenome100 project (click to view on ENA)"
       prjna545868:
         description: "Bird 10K (click to view on ENA)"
       prjna813333:
         description: "Canada Biogenome Project (click to view on ENA)"
+      prjna706690:
+        description: "Canada 150 Sequencing Initiative (click to view on ENA)"
       prjeb49670:
         description: "Catalan Biogenome Project (click to view on ENA)"
       prjna720569:
         description: "California Conservation Genomics Project (click to view on ENA)"
+      prjna1020146:
+        description: "Cetacean Genomes Project (click to view on ENA)"
       prjeb40665:
         description: "Darwin Tree of Life (click to view on ENA)"
+      prjeb65317:
+        description: "Earth Biogenome Project Norway (click to view on ENA)"
       prjna712951:
         description: "ENDEMIXIT (click to view on ENA)"
       prjeb61747:
         description: "ERGA Biodiversity Genomics Europe (click to view on ENA)"
+      prjeb66264:
+        description: "ERGA Community Genomes (click to view on ENA)"
+      prjeb49197:
+        description: "The Swiss node of the European Reference Genome Atlas  (click to view on ENA)"
       prjeb47820:
         description: "ERGA Pilot (click to view on ENA)"
       prjeb43510:
         description: "European Reference Genome Atlas (click to view on ENA)"
       prjna393850:
         description: "EUROFISH (click to view on ENA)"
+      prjna1180976:
+        description: "Genomics of the Brazilian Biodiversity (click to view on ENA)"
       prjna649812:
         description: "Global Invertebrate Genomics Alliance (click to view on ENA)"
       prjna163993:
@@ -91,10 +113,18 @@ attributes:
         description: "MetaInvert (click to view on ENA)"
       prjna1046164:
         description: "Ocean Genomes (click to view on ENA)"
+      prjeb71705:
+        description: "Project Psyche (click to view on ENA)"
       prjna707598:
         description: "Squalomix (click to view on ENA)"
+      prjna1075750:
+        description: "Threatened Species Initiative (click to view on ENA)"
       prjna489243:
         description: "Vertebrate Genomes Project (click to view on ENA)"
+      prjna955268:
+        description: "Yggdrasil (click to view on ENA)"
+      prjna312960:
+        description: "Zoonomia (click to view on ENA)"
   biosample:
     constraint:
       len: 32
@@ -302,11 +332,11 @@ attributes:
   qv_score:
     constraint:
       min: 1
-      type: 4dp
     description: VGP Quality Value score computed with gfastats
     display_group: metrics
     display_level: 2
     display_name: Quality Value score
+    type: 4dp
   linked_accession:
     display_group: linked assemblies
     type: keyword
@@ -315,7 +345,16 @@ attributes:
     type: keyword
   mitochondrion_assembly_span:
     display_group: linked assemblies
-    type: keyword
+    constraint:
+      min: 0
+      max: 100000000
+    units: bases
+    bins:
+      min: 0
+      max: 100000000
+      count: 10
+      scale: log10
+    type: integer
   mitochondrion_gc_percent:
     display_group: linked assemblies
     constraint:
@@ -331,7 +370,16 @@ attributes:
     type: keyword
   plastid_assembly_span:
     display_group: linked assemblies
-    type: keyword
+    constraint:
+      min: 0
+      max: 100000000
+    units: bases
+    bins:
+      min: 0
+      max: 100000000
+      count: 10
+      scale: log10
+    type: integer
   plastid_gc_percent:
     display_group: linked assemblies
     constraint:

--- a/sources/assembly-data/TAXON_assembly.types.yaml
+++ b/sources/assembly-data/TAXON_assembly.types.yaml
@@ -98,6 +98,8 @@ attributes:
     taxon_name: mitochondrion_assembly_span
     taxon_key: mitochondrion_assembly_span
     taxon_display_name: mitochondrion span
+    taxon_summary: median
+    taxon_traverse: median
     taxon_traverse_limit: phylum
     taxon_display_level: 2
   mitochondrion_gc_percent:
@@ -119,6 +121,8 @@ attributes:
     taxon_name: plastid_assembly_span
     taxon_key: plastid_assembly_span
     taxon_display_name: plastid span
+    taxon_summary: median
+    taxon_traverse: median
     taxon_traverse_limit: phylum
     taxon_display_level: 2
   plastid_gc_percent:


### PR DESCRIPTION
**Addresses some identified import failures and updates:**
1. mitochondrion_ and plastid_ `assembly_span` fields are appearing as empty fields in the taxon index 
> when there is no `summary` set in the ATTR yaml - it will show up as a completely empty cell in the UI table instead of null values (dashes)
2. updates translation of bioproject IDs to project acronyms
3. removes unnecessary identifiers from taxon-assembly .yaml
> I have commented out the `source_slug` specification as a header because the blobtk validation test currently complains about it (I'll compile a list of places where this happens so they can be addressed collectively)

