### PR TITLE
validated assembly-data-taxon config files

### DIFF
--- a/sources/assembly-data-taxon/cngb_taxon.types.yaml
+++ b/sources/assembly-data-taxon/cngb_taxon.types.yaml
@@ -37,7 +37,7 @@ identifiers:
 metadata:
   source_slug:
     header: assemblyAccession
-names:
+taxon_names:
   common_name:
     header: commonName
 taxonomy:

--- a/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
+++ b/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
@@ -496,7 +496,7 @@ metadata:
     header: primaryValue
     # source_slug:
     #   header: genbankAccession
-names:
+taxon_names:
   common_name:
     header: commonName
 taxonomy:


### PR DESCRIPTION
changed `names` to `taxon_names` on config yamls

## Summary by Sourcery

Enhancements:
- Update cngb_taxon.types.yaml and ncbi_datasets_eukaryota_taxon.types.yaml to use `taxon_names` instead of `names` for the common_name mapping.