### PR TITLE
Add blobtk validated fixes to taxon .yaml

### DIFF
--- a/sources/assembly-data-sample/TAXON_assembly.types.yaml
+++ b/sources/assembly-data-sample/TAXON_assembly.types.yaml
@@ -1,0 +1,137 @@
+attributes:
+  bioproject:
+    taxon_display_group: assembly
+    taxon_summary:
+      - list
+    taxon_traverse: list
+    taxon_traverse_direction: up
+    taxon_display_level: 2
+  biosample:
+    taxon_display_group: assembly
+    taxon_summary:
+      - list
+    taxon_traverse: list
+    taxon_traverse_direction: up
+    taxon_display_level: 2
+  gene_count:
+    taxon_display_group: assembly
+    taxon_summary:
+      - primary
+      - median
+      - min
+      - max
+      - count
+    taxon_display_level: 2
+  chromosome_count:
+    taxon_display_group: assembly
+    taxon_summary:
+      - primary
+      - mode
+      - median
+      - min
+      - max
+      - count
+    taxon_display_level: 2
+  assembly_level:
+    taxon_display_group: assembly
+    taxon_summary:
+      - primary
+      - enum
+    taxon_traverse: enum
+    taxon_traverse_direction: up
+  assembly_span:
+    taxon_display_group: assembly
+    taxon_summary:
+      - primary
+      - median
+      - min
+      - max
+      - count
+    taxon_traverse: median
+    taxon_traverse_direction: both
+  contig_n50:
+    taxon_display_group: assembly
+    taxon_summary:
+      - primary
+      - max
+      - median
+      - min
+      - count
+    taxon_traverse_direction: up
+    taxon_traverse: median
+    taxon_display_level: 2
+  scaffold_n50:
+    taxon_display_group: assembly
+    taxon_summary:
+      - primary
+      - max
+      - median
+      - min
+      - count
+    taxon_traverse_direction: up
+    taxon_traverse: median
+    taxon_display_level: 2
+  last_updated:
+    taxon_display_group: assembly
+    taxon_name: assembly_date
+    taxon_summary:
+      - primary
+      - max
+      - min
+    taxon_traverse: min
+    taxon_traverse_direction: up
+  ebp_standard_date:
+    taxon_display_group: assembly
+    taxon_summary:
+      - min
+      - max
+    taxon_traverse: min
+    taxon_traverse_direction: up
+  ebp_standard_criteria:
+    taxon_display_group: assembly
+    taxon_summary:
+      - list
+    taxon_traverse: list
+    taxon_traverse_direction: up
+  mitochondrion_assembly_span:
+    taxon_display_group: mitochondrion_assembly
+    taxon_name: mitochondrion_assembly_span
+    taxon_key: mitochondrion_assembly_span
+    taxon_display_name: mitochondrion span
+    taxon_traverse_limit: phylum
+    taxon_display_level: 2
+  mitochondrion_gc_percent:
+    taxon_display_group: mitochondrion_assembly
+    taxon_name: mitochondrion_gc_percent
+    taxon_key: mitochondrion_gc_percent
+    taxon_display_name: mitochondrion gc percent
+    taxon_traverse_limit: phylum
+    taxon_display_level: 2
+    taxon_summary: median
+    taxon_traverse: median
+    taxon_bins:
+      min: 0
+      max: 100
+      count: 10
+      scale: linear
+  plastid_assembly_span:
+    taxon_display_group: plastid_assembly
+    taxon_name: plastid_assembly_span
+    taxon_key: plastid_assembly_span
+    taxon_display_name: plastid span
+    taxon_traverse_limit: phylum
+    taxon_display_level: 2
+  plastid_gc_percent:
+    taxon_display_group: plastid_assembly
+    taxon_name: plastid_gc_percent
+    taxon_key: plastid_gc_percent
+    taxon_display_name: plastid gc percent
+    taxon_traverse_limit: phylum
+    taxon_display_level: 2
+    taxon_summary: median
+    taxon_traverse: median
+    taxon_bins:
+      min: 0
+      max: 100
+      count: 10
+      scale: linear

--- a/sources/genomesize-karyotype/FILE_DTOL_flowering_Plant_karyotypes.types.yaml
+++ b/sources/genomesize-karyotype/FILE_DTOL_flowering_Plant_karyotypes.types.yaml
@@ -34,7 +34,7 @@ attributes:
       - " (+"
       - ") "
       - ")"
-names:
+taxon_names:
   common_name:
     header: Vernacular
 taxonomy:

--- a/sources/lineages/taxon_id_odb10_lineage.types.yaml
+++ b/sources/lineages/taxon_id_odb10_lineage.types.yaml
@@ -85,7 +85,6 @@ attributes:
     name: odb10_lineage
     summary: list
     traverse: false
-    traverse_direction: false
 taxonomy:
   taxon_id:
     header: taxon_id

--- a/sources/lineages/taxon_id_odb10_lineage.types.yaml
+++ b/sources/lineages/taxon_id_odb10_lineage.types.yaml
@@ -85,7 +85,7 @@ attributes:
     name: odb10_lineage
     summary: list
     traverse: false
-    traverse_direction: none
+    traverse_direction: false
 taxonomy:
   taxon_id:
     header: taxon_id

--- a/sources/status-lists/ATTR_seq_status_project.types.yaml
+++ b/sources/status-lists/ATTR_seq_status_project.types.yaml
@@ -19,27 +19,26 @@ defaults:
         - sample_collected
         - sample_available
     value_metadata:
-      default:
-        sample_available:
-          description: "Project has available samples for the taxon"
-        sample_collected:
-          description: "Project has collected samples for the taxon"
-        sample_acquired:
-          description: Samples received by sequencing center
-        in_progress:
-          description: Sequencing started but assembly not yet publicly available
-        data_generation:
-          description: Lab work in progress
-        in_assembly:
-          description: In assembly
-        insdc_submitted:
-          description: Assembly submitted to INSDC but not yet publicly available
-        open:
-          description: Data publicly available
-        insdc_open:
-          description: Data publicly available on INSDC sequence repositories
-        published:
-          description: Publication describing assembly is available
+      sample_available:
+        description: "Project has available samples for the taxon"
+      sample_collected:
+        description: "Project has collected samples for the taxon"
+      sample_acquired:
+        description: Samples received by sequencing center
+      in_progress:
+        description: Sequencing started but assembly not yet publicly available
+      data_generation:
+        description: Lab work in progress
+      in_assembly:
+        description: In assembly
+      insdc_submitted:
+        description: Assembly submitted to INSDC but not yet publicly available
+      open:
+        description: Data publicly available
+      insdc_open:
+        description: Data publicly available on INSDC sequence repositories
+      published:
+        description: Publication describing assembly is available
 attributes:
   sequencing_status:
     description: Most advanced sequencing status for taxon across all projects

--- a/sources/status-lists/ATTR_target_contributor_status_lists.types.yaml
+++ b/sources/status-lists/ATTR_target_contributor_status_lists.types.yaml
@@ -34,35 +34,35 @@ attributes:
         - DERB
         - OXF
         - VIEN
-      value_metadata:
-        DALU:
-          description: "Dalhousie University"
-        GHC:
-          description: Geomar Helmholtz Centre
-        MBA:
-          description: Marine Biological Association
-        NHM:
-          description: Natural History Museum
-        NSU:
-          description: Nova Southeastern University
-        PSU:
-          description: Portland State University
-        QMUL:
-          description: Queen Mary University of London
-        RBGE:
-          description: Royal Botanic Garden Edinburgh
-        KEW:
-          description: Royal Botanic Gardens Kew
-        SAN:
-          description: Sanger Institute
-        UBC:
-          description: University of British Columbia
-        DERB:
-          description: University of Derby
-        OXF:
-          description: University of Oxford
-        VIEN:
-          description: University Of Vienna 
+    value_metadata:
+      DALU:
+        description: "Dalhousie University"
+      GHC:
+        description: Geomar Helmholtz Centre
+      MBA:
+        description: Marine Biological Association
+      NHM:
+        description: Natural History Museum
+      NSU:
+        description: Nova Southeastern University
+      PSU:
+        description: Portland State University
+      QMUL:
+        description: Queen Mary University of London
+      RBGE:
+        description: Royal Botanic Garden Edinburgh
+      KEW:
+        description: Royal Botanic Gardens Kew
+      SAN:
+        description: Sanger Institute
+      UBC:
+        description: University of British Columbia
+      DERB:
+        description: University of Derby
+      OXF:
+        description: University of Oxford
+      VIEN:
+        description: University Of Vienna 
   number_acquired:
     description: Count of samples received by sequencing center
     display_name: Number acquired

--- a/sources/status-lists/FILE_Open_Green_Genomes.types.yaml
+++ b/sources/status-lists/FILE_Open_Green_Genomes.types.yaml
@@ -31,13 +31,13 @@ attributes:
   insdc_open:
     header: sequencing_status
     translate:
-      open:
-      in_progress:
+      open:  ""
+      in_progress:  ""
   open:
     header: sequencing_status
     translate:
       open: OGG
-      in_progress:
+      in_progress: ""
 taxonomy:
   species:
     header: [genus, species]

--- a/sources/status-lists/FILE_Primate_genomes.types.yaml
+++ b/sources/status-lists/FILE_Primate_genomes.types.yaml
@@ -28,7 +28,7 @@ attributes:
     header: sequencing_status
     translate:
       insdc_open: PRGP
-      open:
+      open: ""
 taxonomy:
   order:
     header: order

--- a/sources/status-lists/FILE_jgi1kfg_status.types.yaml
+++ b/sources/status-lists/FILE_jgi1kfg_status.types.yaml
@@ -17,31 +17,31 @@ attributes:
     translate:
       Permanent Draft: in_progress
       incomplete: in_progress
-      targeted:
+      targeted: ""
   sequencing_status_1kfg:
     header: projectStatus
     translate:
       Permanent Draft: in_progress
       incomplete: in_progress
-      targeted:
+      targeted: ""
   sample_collected:
     header: projectStatus
     translate:
       Permanent Draft: 1KFG
       incomplete: 1KFG
-      targeted:
+      targeted: ""
   sample_acquired:
     header: projectStatus
     translate:
       Permanent Draft: 1KFG
       incomplete: 1KFG
-      targeted:
+      targeted: ""
   in_progress:
     header: projectStatus
     translate:
       Permanent Draft: 1KFG
       incomplete: 1KFG
-      targeted:
+      targeted: ""
 taxonomy:
   taxon_id:
     header: ncbiTaxId


### PR DESCRIPTION
Assembly files are working fine after cleanup. Adding the taxon validated files now + cleaning up S3 bucket to avoid conflicts.

A few questions @rjchallis about `assembly-data-sample`: 

- Is the config for samples (`resources/assembly-data-sample/ncbi_datasets_sample.types.yaml`) added back after test import the proper file (see options attached).
-  Do we need the second copy of  (`TAXON-assemblies.types.yaml`) in the sample directory (including S3 resources)? 
- I am assuming config in samples index should not be deleted from resources, so the parse script can work on it. Can you confirm?

## Summary by Sourcery

Add validated taxon assembly configuration and clean up existing status-list YAML definitions

New Features:
- Introduce TAXON_assembly.types.yaml in sources/assembly-data-sample to define taxon‐level assembly and organelle metrics

Enhancements:
- Flatten and relocate value_metadata and defaults in status-list YAMLs for contributor and sequencing status attributes
- Standardize translation mappings by replacing redundant values with empty strings for 'targeted' and status keys across multiple status-list files
- Rename and adjust configuration keys (e.g., change 'names' to 'taxon_names' and correct traverse_direction flag for lineage definitions)