### PR TITLE
Csc curation

### DIFF
--- a/.github/workflows/test_assembly-data.yml
+++ b/.github/workflows/test_assembly-data.yml
@@ -6,7 +6,7 @@ env:
   TAXROOT: 2759
 
 jobs:
-  run_test:
+  get_dockers:
     runs-on: [self-hosted, runner3]
     steps:
       - name: Get dockers


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Rename 'run_test' job to 'get_dockers' in the test_assembly-data GitHub Actions workflow to clarify its purpose