### PR TITLE
Add CULI, AEGIS, 959NG, GBB and Squalomix assembly info

### DIFF
--- a/sources/assembly-data-sample/ATTR_assembly.types.yaml
+++ b/sources/assembly-data-sample/ATTR_assembly.types.yaml
@@ -49,6 +49,10 @@ attributes:
         link: https://www.ebi.ac.uk/ena/browser/view/{}
       prjna533106:
         description: "Earth Biogenome Project (click to view on ENA)"
+      prjeb81973:
+        description: "The 959 Nematode Genomes Project (click to view on ENA)"
+      prjeb80366:
+        description: "Ancient Environmental Genomics Initiative for Sustainability (click to view on ENA)"
       prjna811786:
         description: "Africa Biogenome Project (click to view on ENA)"
       prjna555319:
@@ -77,6 +81,8 @@ attributes:
         description: "European Reference Genome Atlas (click to view on ENA)"
       prjna393850:
         description: "EUROFISH (click to view on ENA)"
+      prjna1180976:
+        description: "Genomics of Brazilian Biodiversity (click to view on ENA)"
       prjna649812:
         description: "Global Invertebrate Genomics Alliance (click to view on ENA)"
       prjna163993:

--- a/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
+++ b/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
@@ -15,6 +15,7 @@ attributes:
     translate:
       PRJNA533106: EBP
       PRJEB33226: 25GP
+      PRJEB81973: 959NG
       PRJEB80366: AEGIS
       PRJNA811786: AFRICABP
       PRJNA555319: AG100PEST
@@ -74,6 +75,7 @@ attributes:
     translate:
       PRJNA533106: EBP
       PRJEB33226: 25GP
+      PRJEB81973: 959NG
       PRJEB80366: AEGIS
       PRJNA811786: AFRICABP
       PRJNA555319: AG100PEST
@@ -146,6 +148,13 @@ attributes:
       - ;
     translate:
       PRJEB33226: insdc_open
+  sequencing_status_959ng:
+    display_group: sequencing_status
+    header: bioProjectAccession
+    separator:
+      - ;
+    translate:
+      PRJEB81973: insdc_open
   sequencing_status_aegis:
     description: Sequencing status for AEGIS
     display_name: Sequencing status AEGIS
@@ -365,6 +374,13 @@ attributes:
       - ;
     translate:
       PRJNA1075727: insdc_open
+  sequencing_status_gbb:
+    display_group: sequencing_status
+    header: bioProjectAccession
+    separator:
+      - ;
+    translate:
+      PRJNA1180976: insdc_open
   sequencing_status_giga:
     display_group: sequencing_status
     header: bioProjectAccession

--- a/sources/assembly-data/ATTR_assembly.types.yaml
+++ b/sources/assembly-data/ATTR_assembly.types.yaml
@@ -49,6 +49,10 @@ attributes:
         link: https://www.ebi.ac.uk/ena/browser/view/{}
       prjna533106:
         description: "Earth Biogenome Project (click to view on ENA)"
+      prjeb81973:
+        description: "The 959 Nematode Genomes Project (click to view on ENA)"
+      prjeb80366:
+        description: "Ancient Environmental Genomics Initiative for Sustainability (click to view on ENA)"
       prjna811786:
         description: "Africa Biogenome Project (click to view on ENA)"
       prjna555319:
@@ -77,6 +81,8 @@ attributes:
         description: "European Reference Genome Atlas (click to view on ENA)"
       prjna393850:
         description: "EUROFISH (click to view on ENA)"
+      prjna1180976:
+        description: "Genomics of Brazilian Biodiversity (click to view on ENA)"
       prjna649812:
         description: "Global Invertebrate Genomics Alliance (click to view on ENA)"
       prjna163993:

--- a/sources/btk/ATTR_assembly.types.yaml
+++ b/sources/btk/ATTR_assembly.types.yaml
@@ -49,6 +49,10 @@ attributes:
         link: https://www.ebi.ac.uk/ena/browser/view/{}
       prjna533106:
         description: "Earth Biogenome Project (click to view on ENA)"
+      prjeb81973:
+        description: "The 959 Nematode Genomes Project (click to view on ENA)"
+      prjeb80366:
+        description: "Ancient Environmental Genomics Initiative for Sustainability (click to view on ENA)"
       prjna811786:
         description: "Africa Biogenome Project (click to view on ENA)"
       prjna555319:
@@ -77,6 +81,8 @@ attributes:
         description: "European Reference Genome Atlas (click to view on ENA)"
       prjna393850:
         description: "EUROFISH (click to view on ENA)"
+      prjna1180976:
+        description: "Genomics of Brazilian Biodiversity (click to view on ENA)"
       prjna649812:
         description: "Global Invertebrate Genomics Alliance (click to view on ENA)"
       prjna163993:

--- a/sources/genomesize-karyotype/ATTR_genome_size.types.yaml
+++ b/sources/genomesize-karyotype/ATTR_genome_size.types.yaml
@@ -48,6 +48,7 @@ attributes:
         - pulse field gel electrophoresis
         - reassociation kinetics
         - whole genome sequencing
+        - qPCR
     description: C value estimation method
     long_description: Method used to estimate the C value in picograms
     display_level: 2
@@ -133,6 +134,7 @@ attributes:
         - Red blood cells
         - Retinal cells
         - Salivary gland
+        - Skeletal muscle
         - Somatic cells
         - Sperm
         - Spleen

--- a/sources/status-lists/ATTR_seq_status_project.types.yaml
+++ b/sources/status-lists/ATTR_seq_status_project.types.yaml
@@ -100,6 +100,9 @@ attributes:
   sequencing_status_cgp:
     description: Sequencing status for Cetaceans Genomes Project
     display_name: Sequencing status CGP
+  sequencing_status_culi:
+    description: Sequencing status for Culicidae Genomes
+    display_name: Sequencing status CULI
   sequencing_status_dtol:
     description: Sequencing status for Darwin Tree of Life project
     display_name: Sequencing status DToL
@@ -145,6 +148,9 @@ attributes:
   sequencing_status_gap:
     description: Sequencing status for Genomics for Australian Plants Project
     display_name: Sequencing status GAP
+  sequencing_status_gbb:
+    description: Sequencing status for Genomics of the Brazilian Biodiversity Project
+    display_name: Sequencing status GBB
   sequencing_status_gbr:
     description: Sequencing status for Great Barrier Reef SeaQuence Project
     display_name: Sequencing status GBR

--- a/sources/status-lists/ATTR_status_lists.types.yaml
+++ b/sources/status-lists/ATTR_status_lists.types.yaml
@@ -29,6 +29,7 @@ defaults:
         - cfgp
         - cgp
         - cngb
+        - culi
         - dtol
         - ebpn
         - ebphk
@@ -113,6 +114,8 @@ defaults:
         description: "Cartilaginous Fish Genome Project (click to view GoaT project page)"
       cgp:
         description: "Cetaceans Genomes Project (click to view GoaT project page)"
+      culi:
+        description: "Culicidae Genomes (click to view GoaT project page)"
       dtol:
         description: "Darwin Tree of Life (click to view GoaT project page)"
       ebpn:
@@ -139,6 +142,8 @@ defaults:
         description: "Global Ant Genomics Alliance (click to view GoaT project page)"
       gap:
         description: "Genomics for Australian Plants (click to view GoaT project page)"
+      gbb:
+        description: "Genomics of the Brazilian Biodiversity (click to view GoaT project page
       gbr:
         description: "Great Barrier Reef SeaQuence Project (click to view GoaT project page)"
       giga:

--- a/sources/status-lists/ATTR_target_lists.types.yaml
+++ b/sources/status-lists/ATTR_target_lists.types.yaml
@@ -29,6 +29,7 @@ defaults:
         - cfgp
         - cgp
         - cngb
+        - culi
         - dtol
         - ebpn
         - ebphk
@@ -44,6 +45,7 @@ defaults:
         - fish
         - gaga
         - gap
+        - gbb
         - gbr
         - giga
         - hk-ebp
@@ -113,6 +115,8 @@ defaults:
         description: "Cartilaginous Fish Genome Project (click to view GoaT project page)"
       cgp:
         description: "Cetaceans Genomes Project (click to view GoaT project page)"
+      culi:
+        description: "Culicidae Genomes (click to view GoaT project page)"
       dtol:
         description: "Darwin Tree of Life (click to view GoaT project page)"
       ebpn:
@@ -139,6 +143,8 @@ defaults:
         description: "Global Ant Genomics Alliance (click to view GoaT project page)"
       gap:
         description: "Genomics for Australian Plants (click to view GoaT project page)"
+      gbb:
+        description: "Genomics of the Brazilian Biodiversity (click to view GoaT project page
       gbr:
         description: "Great Barrier Reef SeaQuence Project (click to view GoaT project page)"
       giga:


### PR DESCRIPTION
- Adds and updates project lists for (CULI, AEGIS, 959NG, Squalomix, GBB)
- Adds karyotype and genome size from Squalomix targets

## Summary by Sourcery

Add support for CULI, AEGIS, 959NG, and GBB assembly metadata by updating project lists, sequencing status categories, and attribute descriptions, and enhance genome size attributes with Squalomix-specific options.

New Features:
- Add assembly and sample attribute entries for PRJEB81973 (959NG), PRJEB80366 (AEGIS), PRJNA1180976 (GBB), and CULI with descriptions and ENA links
- Introduce sequencing_status groups for 959NG, GBB, and CULI in NCBI datasets and status-list configurations

Enhancements:
- Extend genome size attributes with qPCR estimation method and skeletal muscle tissue for Squalomix targets