### PR TITLE
restore nhm api fetching

### DIFF
--- a/scripts/api/api_config.py
+++ b/scripts/api/api_config.py
@@ -1,6 +1,6 @@
 import json
-import yaml
 import requests
+import yaml
 
 #####################################################################
 # VGL
@@ -73,19 +73,20 @@ nhm_post_data = {
 
 
 nhm_url = "https://data.nhm.ac.uk/api/3/action/vds_multi_query"
-nhm_headers = {
-    "content-type": "application/json",
-    "user-agent": "GoaT DToL script (curators contact: goat@genomehubs.org)",
-}
+nhm_headers = {"content-type": "application/json", "user-agent": "GoaT DToL script"}
 
 
 def nhm_url_opener(**kwargs):
+    print("NHM API request sent")
+    print(nhm_url)
+    print(nhm_post_data)
     return requests.post(nhm_url, headers=nhm_headers, json=nhm_post_data)
 
 
 def nhm_api_count_handler(r_text):
     j = json.loads(r_text)
     nhm_total = j["result"]["total"]
+    print(f"NHM total count: {nhm_total}")
     return nhm_total
 
 

--- a/scripts/api/api_to_tsv.py
+++ b/scripts/api/api_to_tsv.py
@@ -3,29 +3,49 @@
 Will generate .tsv files from api-retrieved data for GoaT import.
 """
 
-
 import sys
-import api_tools as at
+
 import api_config as cfg
+import api_tools as at
+
+"""try to access each API 3 times in case of failure or timeout"""
 
 
-at.get_from_source(
+def access_api_with_retries(
+    url_opener, api_count_handler, row_handler, fieldnames, output_filename, token=None
+):
+    for i in range(3):
+        try:
+            at.get_from_source(
+                url_opener,
+                api_count_handler,
+                row_handler,
+                fieldnames,
+                output_filename,
+                token=token,
+            )
+            break  # Exit the loop if successful
+        except Exception as e:
+            print(f"Error occurred while accessing API: {e}")
+            if i == 2:
+                print(f"Max retries for {output_filename} reached. Exiting.")
+
+
+access_api_with_retries(
     cfg.vgl_url_opener,
     cfg.vgl_hub_count_handler,
     cfg.vgl_row_handler,
     cfg.vgl_fieldnames,
     f"{sys.argv[1]}/{cfg.vgl_output_filename}",
 )
-
-at.get_from_source(
+access_api_with_retries(
     cfg.nhm_url_opener,
     cfg.nhm_api_count_handler,
     cfg.nhm_row_handler,
     cfg.nhm_fieldnames,
     f"{sys.argv[1]}/{cfg.nhm_output_filename}",
 )
-
-at.get_from_source(
+access_api_with_retries(
     cfg.sts_url_opener,
     cfg.sts_api_count_handler,
     cfg.sts_row_handler,

--- a/scripts/api/api_tools.py
+++ b/scripts/api/api_tools.py
@@ -1,5 +1,6 @@
 # import requests
 import csv
+import os
 import sys
 from traceback import format_exc
 
@@ -15,7 +16,7 @@ def get_from_source(
         rows = row_handler(
             r_text=r_text, result_count=result_count, fieldnames=fieldnames, token=token
         )
-
+        os.makedirs(os.path.dirname(output_filename), exist_ok=True)
         with open(output_filename, "w") as output_file:
             writer = csv.writer(output_file, delimiter="\t", lineterminator="\n")
             writer.writerow(fieldnames)


### PR DESCRIPTION
add helper for api fetching, update nhm headers and make sure output directory exists

## Summary by Sourcery

Add retry logic to API fetching, ensure output directories exist, and update NHM API handling.

New Features:
- Introduce access_api_with_retries helper to retry API calls up to three times on failure.

Enhancements:
- Automatically create output directory before writing TSV files.
- Standardize NHM API headers and add debug print statements for request URL and total count.