### PR TITLE
nhm api request improvements

### DIFF
--- a/scripts/api/api_config.py
+++ b/scripts/api/api_config.py
@@ -73,13 +73,15 @@ nhm_post_data = {
 
 
 nhm_url = "https://data.nhm.ac.uk/api/3/action/vds_multi_query"
-nhm_headers = {"content-type": "application/json", "user-agent": "GoaT DToL script"}
+nhm_headers = {
+    "content-type": "application/json",
+    "user-agent": "GoaT DToL script",
+    "accept": "application/json",
+}
 
 
 def nhm_url_opener(**kwargs):
-    print("NHM API request sent")
     print(nhm_url)
-    print(nhm_post_data)
     return requests.post(nhm_url, headers=nhm_headers, json=nhm_post_data)
 
 

--- a/scripts/api/api_to_tsv.py
+++ b/scripts/api/api_to_tsv.py
@@ -4,6 +4,7 @@ Will generate .tsv files from api-retrieved data for GoaT import.
 """
 
 import sys
+import time
 
 import api_config as cfg
 import api_tools as at
@@ -29,6 +30,7 @@ def access_api_with_retries(
             print(f"Error occurred while accessing API: {e}")
             if i == 2:
                 print(f"Max retries for {output_filename} reached. Exiting.")
+            time.sleep(10)  # Wait before retrying
 
 
 access_api_with_retries(

--- a/scripts/api/api_tools.py
+++ b/scripts/api/api_tools.py
@@ -10,6 +10,8 @@ def get_from_source(
 ):
     try:
         r = url_opener(token=token)
+        if r.status_code != 200:
+            raise ValueError(f"bad response: {r.status_code}")
         r_text = r.text
         result_count = count_handler(r_text)
         print(f"count is {result_count}")


### PR DESCRIPTION
- adds accept header to nhm post request
- raise exception if response !=200
- sleep before the retry

## Summary by Sourcery

Improve NHM API request robustness by adding an Accept header, enforcing status checks, and delaying retries

Enhancements:
- Include Accept: application/json header in NHM API POST requests
- Raise an exception for non-200 HTTP responses
- Add a 10-second delay before retrying failed API requests

Chores:
- Remove debug print statements in NHM API request functions