### PR TITLE
use Jittered Exponential Backoff  for API retries

### DIFF
--- a/scripts/api/api_to_tsv.py
+++ b/scripts/api/api_to_tsv.py
@@ -39,7 +39,7 @@ def access_api_with_retries(
             r = url_opener(token=token)
             if r.status_code == 200:
                 return
-        except (requests.ConnectionError, requests.HTTPError) as e:
+        except (requests.ConnectionError, requests.HTTPError, requests.Timeout, requests.RequestException) as e:
             print(
                 f"Connection error {e} occurred for attempt {attempt +1}/{retries} "
                 f"of accessing API. Retrying in {delay:.1f} seconds..."

--- a/scripts/api/api_tools.py
+++ b/scripts/api/api_tools.py
@@ -14,7 +14,7 @@ def get_from_source(
             raise ValueError(f"bad response: {r.status_code}")
         r_text = r.text
         result_count = count_handler(r_text)
-        print(f"count is {result_count}")
+        print(f"count to create {output_filename} is {result_count}")
         rows = row_handler(
             r_text=r_text, result_count=result_count, fieldnames=fieldnames, token=token
         )


### PR DESCRIPTION
Addressing current issues to connect and retreve data from NHM and STS APIs.

## Summary by Sourcery

Improve API retry logic by introducing jittered exponential backoff with customizable retry count and enhanced error handling, and clarify logging output for API responses.

Enhancements:
- Replace fixed sleep retries with jittered exponential backoff based on attempt count and configurable max delay
- Catch and log specific connection and HTTP errors with retry attempt details before backoff
- Raise an exception after exhausting retries instead of silent loop exit

Chores:
- Update API tools print statement to include output filename in the record count message