### PR TITLE
fix typo apitools

### DIFF
--- a/scripts/api/api_tools.py
+++ b/scripts/api/api_tools.py
@@ -14,7 +14,7 @@ def get_from_source(
             raise ValueError(f"bad response: {r.status_code}")
         r_text = r.text
         result_count = count_handler(r_text)
-        print(f"count to create {output_filename} is {result_count}")
+        print(f"count to create is {result_count}")
         rows = row_handler(
             r_text=r_text, result_count=result_count, fieldnames=fieldnames, token=token
         )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the print message in api_tools to remove the undefined output_filename placeholder