### PR TITLE
Add descriptions missing from taxon and assembly attributes

### DIFF
--- a/scripts/api/api_to_tsv.py
+++ b/scripts/api/api_to_tsv.py
@@ -39,7 +39,12 @@ def access_api_with_retries(
             r = url_opener(token=token)
             if r.status_code == 200:
                 return
-        except (requests.ConnectionError, requests.HTTPError, requests.Timeout, requests.RequestException) as e:
+        except (
+            requests.ConnectionError,
+            requests.HTTPError,
+            requests.Timeout,
+            requests.RequestException,
+        ) as e:
             print(
                 f"Connection error {e} occurred for attempt {attempt +1}/{retries} "
                 f"of accessing API. Retrying in {delay:.1f} seconds..."
@@ -55,13 +60,13 @@ access_api_with_retries(
     cfg.vgl_fieldnames,
     f"{sys.argv[1]}/{cfg.vgl_output_filename}",
 )
-access_api_with_retries(
-    cfg.nhm_url_opener,
-    cfg.nhm_api_count_handler,
-    cfg.nhm_row_handler,
-    cfg.nhm_fieldnames,
-    f"{sys.argv[1]}/{cfg.nhm_output_filename}",
-)
+# access_api_with_retries(
+#     cfg.nhm_url_opener,
+#     cfg.nhm_api_count_handler,
+#     cfg.nhm_row_handler,
+#     cfg.nhm_fieldnames,
+#     f"{sys.argv[1]}/{cfg.nhm_output_filename}",
+# )
 access_api_with_retries(
     cfg.sts_url_opener,
     cfg.sts_api_count_handler,

--- a/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
+++ b/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
@@ -16,6 +16,7 @@ attributes:
       PRJNA533106: EBP
       PRJEB33226: 25GP
       PRJEB81973: 959NG
+      PRJNA1245457: 1000GCH
       PRJEB80366: AEGIS
       PRJNA811786: AFRICABP
       PRJNA555319: AG100PEST
@@ -65,6 +66,7 @@ attributes:
       PRJNA707598: SQUALOMIX
       PRJNA1075750: TSI
       PRJNA489243: VGP
+      PRJEB96280: WA
       PRJNA955268: YGG
       PRJNA312960: ZOONOMIA
   insdc_open:
@@ -76,6 +78,7 @@ attributes:
       PRJNA533106: EBP
       PRJEB33226: 25GP
       PRJEB81973: 959NG
+      PRJNA1245457: 1000GCH
       PRJEB80366: AEGIS
       PRJNA811786: AFRICABP
       PRJNA555319: AG100PEST
@@ -124,6 +127,7 @@ attributes:
       PRJEB71705: PSYCHE
       PRJNA707598: SQUALOMIX
       PRJNA1075750: TSI
+      PRJEB96280: WA
       PRJNA489243: VGP
       PRJNA955268: YGG
       PRJNA312960: ZOONOMIA
@@ -140,7 +144,7 @@ attributes:
     separator:
       - ;
     translate:
-      TBD: insdc_open
+      PRJNA1245457: insdc_open
   sequencing_status_25gp:
     display_group: sequencing_status
     header: bioProjectAccession
@@ -486,6 +490,13 @@ attributes:
       - ;
     translate:
       PRJNA489243: insdc_open
+  sequencing_status_wa:
+    display_group: sequencing_status
+    header: bioProjectAccession
+    separator:
+      - ;
+    translate:
+      PRJEB96280: insdc_open
   sequencing_status_ygg:
     display_group: sequencing_status
     header: bioProjectAccession

--- a/sources/assembly-data/ATTR_assembly.types.yaml
+++ b/sources/assembly-data/ATTR_assembly.types.yaml
@@ -5,22 +5,28 @@ defaults:
     source: INSDC
 identifiers:
   assembly_id:
+    description: Assembly identifier
     constraint:
       len: 32
     type: keyword
   genbank_accession:
+    description: GenBank accession number
     constraint:
       len: 32
     type: keyword
   refseq_accession:
+    description: RefSeq accession number
     constraint:
       len: 32
     type: keyword
   wgs_accession:
+    description: Whole Genome Shotgun project accession number
     constraint:
       len: 16
     type: keyword
   assembly_name:
+    description: Assembly name
+    long_description: The name assigned to the assembly by the submitter, when provided. Otherwise, a default name in the form ASM#####v#
     constraint:
       len: 64
     type: keyword
@@ -35,6 +41,8 @@ attributes:
         - apicoplast
         - kinetoplast
     description: assembled organelle
+    long_description: The organelle from which the assembly was derived
+    display_level: 2
     type: keyword
   bioproject:
     constraint:
@@ -49,34 +57,60 @@ attributes:
         link: https://www.ebi.ac.uk/ena/browser/view/{}
       prjna533106:
         description: "Earth Biogenome Project (click to view on ENA)"
+      prjna1245457:
+        description: "The 1,000 Chilean Genomes project (click to view on ENA)"
+      prjeb33226:
+        description: "25 Genomes Project (click to view on ENA)"
+      prjeb81973:
+        description: "The 959 Nematode Genomes Project (click to view on ENA)"
+      prjeb80366:
+        description: "Ancient Environmental Genomics Initiative for Sustainability (click to view on ENA)"
       prjna811786:
         description: "Africa Biogenome Project (click to view on ENA)"
       prjna555319:
         description: "Ag100Pest (click to view on ENA)"
+      prjeb51690:
+        description: "Anopheles Reference Genomes Project (click to view on ENA)"
       prjeb43743:
         description: "Aquatic Symbiosis Genomics Project (click to view on ENA)"
+      prjeb64126:
+        description: "ATLASea - an Atlas of Eukaryotic Marine Genomes (click to view on ENA)"
       prjna489245:
-        description: "Bat 1K (click to view on ENA)"
+        description: "Bat1K (click to view on ENA)"
+      prjna923301:
+        description: "The Beenome 100 Project (click to view on ENA)"
       prjna545868:
         description: "Bird 10K (click to view on ENA)"
       prjna813333:
         description: "Canada Biogenome Project (click to view on ENA)"
+      prjna706690:
+        description: "Canada 150 Sequencing Initiative (click to view on ENA)"
       prjeb49670:
         description: "Catalan Biogenome Project (click to view on ENA)"
       prjna720569:
         description: "California Conservation Genomics Project (click to view on ENA)"
+      prjna1020146:
+        description: "Cetaceans Genomes Project (click to view on ENA)"
       prjeb40665:
         description: "Darwin Tree of Life (click to view on ENA)"
+      prjeb65317:
+        description: "Earth Biogenome Project Norway (click to view on ENA)"
       prjna712951:
         description: "ENDEMIXIT (click to view on ENA)"
       prjeb61747:
         description: "ERGA Biodiversity Genomics Europe (click to view on ENA)"
+      prjeb66264:
+        description: "ERGA Community Genomes (click to view on ENA)"
       prjeb47820:
         description: "ERGA Pilot (click to view on ENA)"
+      prjeb49197:
+        description: "ERGA Switzerland (click to view on ENA)"
       prjeb43510:
         description: "European Reference Genome Atlas (click to view on ENA)"
       prjna393850:
         description: "EUROFISH (click to view on ENA)"
+      prjna1180976:
+        description: "Genomics of the Brazilian Biodiversity (click to view on ENA)"
       prjna649812:
         description: "Global Invertebrate Genomics Alliance (click to view on ENA)"
       prjna163993:
@@ -91,11 +125,23 @@ attributes:
         description: "MetaInvert (click to view on ENA)"
       prjna1046164:
         description: "Ocean Genomes (click to view on ENA)"
+      prjeb71705:
+        description: "Project Psyche (click to view on ENA)"
       prjna707598:
         description: "Squalomix (click to view on ENA)"
+      prjna1075750:
+        description: "Threatened Species Initiative (click to view on ENA)"
+      prjeb96280:
+        description: "Wise Ancestors (click to view on ENA)"
       prjna489243:
         description: "Vertebrate Genomes Project (click to view on ENA)"
+      prjna955268:
+        description: "Yggdrasil (click to view on ENA)"
+      prjna312960:
+        description: "Zoonomia (click to view on ENA)"
   biosample:
+    description: INSDC biosample ID
+    long_description: INSDC BioSample from which the sequences in the genome assembly were obtained
     constraint:
       len: 32
     synonyms:
@@ -106,6 +152,8 @@ attributes:
         description: Click to view BioSample record on ENA
         link: https://www.ebi.ac.uk/ena/browser/view/{}
   gene_count:
+    description: Assembly gene count
+    long_description: The total number of genes predicted in the assembly
     display_group: annotation
     display_level: 1
     display_name: Gene count
@@ -118,6 +166,8 @@ attributes:
       count: 10
       scale: log10
   protein_count:
+    description: Assembly protein count
+    long_description: The total number of proteins predicted in the assembly
     display_group: annotation
     display_level: 2
     display_name: Protein count
@@ -125,6 +175,8 @@ attributes:
       min: 1
     type: integer
   pseudogene_count:
+    description: Assembly pseudogene count
+    long_description: The total number of pseudogenes predicted in the assembly
     display_group: annotation
     display_level: 2
     display_name: Pseudogene count
@@ -132,6 +184,8 @@ attributes:
       min: 1
     type: integer
   noncoding_gene_count:
+    description: Assembly non-coding gene count
+    long_description: The total number of non-coding genes predicted in the assembly
     display_group: annotation
     display_level: 2
     display_name: Non-coding gene count
@@ -139,14 +193,19 @@ attributes:
       min: 1
     type: integer
   sample_sex:
+    description: Sample sex
+    long_description: Physical sex of sampled organism
     display_level: 2
     display_name: Sample sex
     type: keyword
   isolate:
+    description: Isolate identifier
+    long_description: The individual isolate from which the sequences in the genome assembly were derived
     display_level: 2
     display_name: Isolate
     type: keyword
   assembly_level:
+    description: The level at which a genome has been assembled
     display_level: 1
     display_name: Assembly level
     type: keyword
@@ -157,10 +216,14 @@ attributes:
         - scaffold
         - contig
   assembly_type:
+    description: Type of assembly
+    long_description: Chromosome or ploidy content of the submitted genome assembly
     display_level: 2
     display_name: Assembly type
     type: keyword
   assembly_span:
+    description: Total length of the assembly
+    long_description: Total sequence length of the genome including unplaced and unlocalized sequences
     display_group: metrics
     display_level: 1
     display_name: Assembly span
@@ -174,6 +237,8 @@ attributes:
       count: 10
       scale: log10
   ungapped_span:
+    description: Total length of the ungapped assembly
+    long_description: Total length of all top-level sequences ignoring gaps. Any stretch of 10 or more Ns in a sequence is treated like a gap
     display_group: metrics
     display_level: 2
     display_name: Ungapped span
@@ -182,6 +247,8 @@ attributes:
     type: long
     units: bases
   contig_n50:
+    description: Contig N50 value
+    long_description: Length such that sequence contigs of this length or longer include half the bases of the assembly
     display_group: metrics
     display_level: 1
     display_name: Contig N50
@@ -195,6 +262,8 @@ attributes:
       count: 10
       scale: log10
   contig_l50:
+    description: Contig L50 value
+    long_description: Number of sequence contigs that are longer than, or equal to, the N50 length and therefore include half the bases of the assembly
     display_group: metrics
     display_level: 2
     display_name: Contig L50
@@ -203,6 +272,8 @@ attributes:
     type: long
     units: bases
   scaffold_n50:
+    description: Scaffold N50 value
+    long_description: Length such that scaffolds of this length or longer include half the bases of the assembly
     display_group: metrics
     display_level: 1
     display_name: Scaffold N50
@@ -216,6 +287,8 @@ attributes:
       count: 10
       scale: log10
   scaffold_l50:
+    description: Scaffold L50 value
+    long_description: Number of scaffolds that are longer than, or equal to, the N50 length and therefore include half the bases of the assembly
     display_group: metrics
     display_level: 2
     display_name: Scaffold L50
@@ -224,6 +297,8 @@ attributes:
     type: long
     units: bases
   contig_count:
+    description: Number of contigs
+    long_description: Total number of sequence contigs in the assembly. Any stretch of 10 or more Ns in a sequence is treated as a gap between two contigs in a scaffold when counting contigs and calculating contig N50 & L50 values
     display_group: metrics
     display_level: 1
     display_name: Contig count
@@ -232,6 +307,8 @@ attributes:
     type: long
     units: bases
   scaffold_count:
+    description: Number of scaffolds
+    long_description: Number of scaffolds including placed, unlocalized, unplaced, alternate loci and patch scaffolds
     display_group: metrics
     display_level: 1
     display_name: Scaffold count
@@ -240,6 +317,8 @@ attributes:
     type: long
     units: bases
   chromosome_count:
+    description: Number of chromosomes in the assembly
+    long_description: Count of nuclear chromosomes in a submitted genome assembly, can be the chromosome count in a single haplotype plus all types of sex chromosomes found in the individual
     display_group: metrics
     display_level: 1
     display_name: Chromosome count
@@ -248,6 +327,8 @@ attributes:
     type: long
     units: bases
   sequence_count:
+    description: Number of Component Sequences
+    long_description: Total number of component WGS or clone sequences in the assembly
     display_group: metrics
     display_level: 2
     display_name: Sequence count
@@ -256,16 +337,19 @@ attributes:
     type: long
     units: bases
   last_updated:
+    description: Date the assembly was last updated by NCBI
     display_level: 2
     display_name: Last updated
     type: date
   ebp_standard_date:
+    description: Date the assembly reached an ebp_standard_criteria
     display_level: 2
     display_name: EBP metric date
     synonyms:
       - ebp_metric_date
     type: date
   ebp_standard_criteria:
+    description: highest EBP standard criteria met by the assembly
     constraint:
       enum:
         - 6.C
@@ -276,14 +360,19 @@ attributes:
     display_name: EBP standard criteria
     type: keyword
   refseq_category:
+    description: RefSeq category assigned to the assembly
+    long_description: The RefSeq category, if present, indicates whether the assembly is a reference genome
     display_level: 2
     display_name: RefSeq category
     type: keyword
   submitter:
+    description: Name of the submitting organization
+    long_description: The submitting consortium or organization. Full submitter information is available in the BioProject
     display_level: 2
     display_name: Submitter
     type: keyword
   gc_percent:
+    description: The percentage of GC base-pairs in the assembly
     display_group: metrics
     display_level: 1
     constraint:
@@ -292,6 +381,7 @@ attributes:
     type: 2dp
     units: "%"
   n_percent:
+    description: The percentage of Ns, undefined bases, in the assembly
     display_group: metrics
     display_level: 2
     constraint:
@@ -303,20 +393,25 @@ attributes:
     constraint:
       min: 1
     type: 4dp
-    description: VGP Quality Value score computed with gfastats
+    description: Quality Value score of the assembly
     display_group: metrics
     display_level: 2
     display_name: Quality Value score
   linked_accession:
+    description: Linked assembly accession
+    long_description: Accession of genome assemblies derived from the same diploid individual
     display_group: linked assemblies
     type: keyword
   source_accession:
+    description: Source of linked assembly accession
     display_group: linked assemblies
     type: keyword
   mitochondrion_assembly_span:
+    description: total length of mitochondrial assembly
     display_group: linked assemblies
     type: keyword
   mitochondrion_gc_percent:
+    description: The percentage of GC base-pairs in the mitochondrial assembly
     display_group: linked assemblies
     constraint:
       min: 0
@@ -324,15 +419,19 @@ attributes:
     type: 2dp
     units: "%"
   mitochondrion_accession:
+    description: Mitochondrion assembly accession
     display_group: linked assemblies
     type: keyword
   mitochondrion_scaffolds:
+    description: Number of scaffolds in the mitochondrial assembly
     display_group: linked assemblies
     type: keyword
   plastid_assembly_span:
+    description: total length of plastid assembly
     display_group: linked assemblies
     type: keyword
   plastid_gc_percent:
+    description: The percentage of GC base-pairs in the plastid assembly
     display_group: linked assemblies
     constraint:
       min: 0
@@ -340,9 +439,11 @@ attributes:
     type: 2dp
     units: "%"
   plastid_accession:
+    description: Plastid assembly accession
     display_group: linked assemblies
     type: keyword
   plastid_scaffolds:
+    description: Number of scaffolds in the plastid assembly
     display_group: linked assemblies
     type: keyword
   assigned_percent:

--- a/sources/lineages/taxon_id_odb10_lineage.types.yaml
+++ b/sources/lineages/taxon_id_odb10_lineage.types.yaml
@@ -81,6 +81,7 @@ attributes:
     display_group: assembly
     display_level: 2
     display_name: Busco_odb10 lineage
+    description: odb10 lineage used in BUSCO analysis
     key: odb10_lineage
     name: odb10_lineage
     summary: list


### PR DESCRIPTION
1. comment out nhm fetching from the workflow: new fetching and direct update to s3 has been set in genomehubs/data to avoid blocking updates to status-lists
code is [here](https://github.com/genomehubs/data/blob/main/flows/updaters/update_nhm_status_list.py) and [here](https://github.com/genomehubs/data/blob/main/flows/updaters/api/api_config.py#L105)

2. Adds more descriptions to `goat-data/sources` types.yaml files:
 - `ATTR_assembly.types.yam`l in souces/assembly-data,
- `ncbi_datasets_eukaryota.taxon.types.yaml`  in /assembly-data-taxon,
- `taxon_id_odb10_lineages` in /lineages

## Summary by Sourcery

Comment out NHM fetching in the api_to_tsv workflow and enrich type definitions with missing description metadata for assembly, taxon, and lineage attributes, as well as extend project code mappings for additional sequencing projects

Enhancements:
- Populate description, long_description, and display metadata for assembly attributes in ATTR_assembly.types.yaml
- Add missing description for odb10_lineage in taxon_id_odb10_lineage.types.yaml
- Extend NCBI eukaryota taxon mappings with new project codes (1000GCH, WA) and sequencing_status group in ncbi_datasets_eukaryota_taxon.types.yaml
- Refactor exception clause formatting in api_to_tsv.py and comment out NHM API update call