### PR TITLE
remove primary from assembly level summary

### DIFF
--- a/sources/assembly-data/TAXON_assembly.types.yaml
+++ b/sources/assembly-data/TAXON_assembly.types.yaml
@@ -35,7 +35,6 @@ attributes:
   assembly_level:
     taxon_display_group: assembly
     taxon_summary:
-      - primary
       - enum
     taxon_traverse: enum
     taxon_traverse_direction: up


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust assembly taxonomy configuration so `assembly_level` is no longer marked as `primary` in the taxon summary.