### PR TITLE
remove sts from auto-updates

### DIFF
--- a/scripts/api/api_to_tsv.py
+++ b/scripts/api/api_to_tsv.py
@@ -67,11 +67,11 @@ access_api_with_retries(
 #     cfg.nhm_fieldnames,
 #     f"{sys.argv[1]}/{cfg.nhm_output_filename}",
 # )
-access_api_with_retries(
-    cfg.sts_url_opener,
-    cfg.sts_api_count_handler,
-    cfg.sts_row_handler,
-    cfg.sts_fieldnames,
-    f"{sys.argv[1]}/{cfg.sts_output_filename}",
-    token=sys.argv[2],
-)
+# access_api_with_retries(
+#     cfg.sts_url_opener,
+#     cfg.sts_api_count_handler,
+#     cfg.sts_row_handler,
+#     cfg.sts_fieldnames,
+#     f"{sys.argv[1]}/{cfg.sts_output_filename}",
+#     token=sys.argv[2],
+# )


### PR DESCRIPTION
Failure in accessing STS API is blocking other status lists rom updating. Instead of applying a fix, I'll create a task to retrieve STS data using the ToL portal directly.

## Summary by Sourcery

Bug Fixes:
- Prevent STS API failures from blocking updates of other status lists by turning off the STS auto-update call.