### PR TITLE
add conservation directory to indexing workflow

### DIFF
--- a/.github/workflows/develop_release.yml
+++ b/.github/workflows/develop_release.yml
@@ -316,6 +316,18 @@ jobs:
                 --config-file sources/goat.yaml \
                 --taxon-dir sources/regional_lists \
                 --taxon-lookup any --taxon-spellcheck"
+      - name: genomehubs index taxon conservation
+        run: |
+          docker run --rm --network=host \
+            -v `pwd`/sources:/genomehubs/sources \
+            genomehubs/genomehubs:develop bash -c \
+              "genomehubs index \
+                --es-host http://es1:9200 \
+                --taxonomy-source ncbi \
+                --config-file sources/goat.yaml \
+                --taxon-dir sources/conservation \
+                --taxon-lookup any --taxon-spellcheck"
+                
       - name: genomehubs index taxon uk_legislation
         run: |
           docker run --rm --network=host \

--- a/.github/workflows/genomehubs-index.yml
+++ b/.github/workflows/genomehubs-index.yml
@@ -126,6 +126,15 @@ jobs:
           directory: regional-lists
           flags: --taxon-lookup any --taxon-spellcheck --blank "N/A" --blank "None"
           type: taxon
+      - name: Index conservation
+        uses: ./.github/workflows/genomehubs-index-directory
+        with:
+          dockerversion: ${{ inputs.dockerversion }}
+          release: ${{ inputs.release }}
+          resources: ${{ inputs.resources }}
+          directory: conservation
+          flags: --taxon-lookup any --taxon-spellcheck
+          type: taxon
       - name: Index uk-legislation
         uses: ./.github/workflows/genomehubs-index-directory
         with:

--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -369,6 +369,17 @@ jobs:
                 --config-file sources/goat.yaml \
                 --taxon-dir sources/regional_lists \
                 --taxon-lookup any --taxon-spellcheck"
+      - name: genomehubs index taxon conservation
+        run: |
+          docker run --rm --network=host \
+            -v `pwd`/sources:/genomehubs/sources \
+            genomehubs/genomehubs:$DOCKERVERSION bash -c \
+              "genomehubs index \
+                --es-host es1:9200 \
+                --taxonomy-source ncbi \
+                --config-file sources/goat.yaml \
+                --taxon-dir sources/conservation \
+                --taxon-lookup any --taxon-spellcheck"
       - name: genomehubs index taxon uk_legislation
         run: |
           docker run --rm --network=host \
@@ -380,7 +391,6 @@ jobs:
                 --config-file sources/goat.yaml \
                 --taxon-dir sources/uk_legislation \
                 --taxon-lookup any --taxon-spellcheck"
-
       - name: genomehubs parse btk
         run: |
           docker run --rm --network=host \


### PR DESCRIPTION
This will set a new display group on GoaT (taxon index) for lists that ca be used to prioritise sequencing based on conservation and habitat remarks.
Test case is CITEs and will be expanded to RedList status, WoRMS habitat, etc.

## Summary by Sourcery

Index conservation taxon lists in GenomeHubs workflows to support sequencing prioritisation based on conservation and habitat data.

New Features:
- Add conservation taxon indexing step to the develop release workflow.
- Add conservation taxon indexing step to the new release workflow.
- Add conservation directory indexing to the shared genomehubs-index workflow.

CI:
- Extend CI release and indexing workflows to process a new conservation taxon directory.