### PR TITLE
change display name to "conservation"

### DIFF
--- a/sources/conservation/ATTR_conservation.types.yaml
+++ b/sources/conservation/ATTR_conservation.types.yaml
@@ -1,7 +1,7 @@
 attributes:
   conservation_list:
     description: List used as source of conservation status information
-    display_group: conservation_status
+    display_group: conservation
     display_level: 2
     display_name: Conservation list
     summary: list
@@ -10,13 +10,13 @@ attributes:
     type: keyword
     constraint:
       enum:
-      - CITES
-      - IUCN
-      - JNCC
+        - CITES
+        - IUCN
+        - JNCC
   cites_category:
     description: Species CITES status
     long_description: Category of taxon in the Convention on International Trade in Endangered Species of Wild Fauna and Flora (CITES).
-    display_group: conservation_status
+    display_group: conservation
     display_level: 2
     display_name: CITES Category
     summary: list
@@ -25,11 +25,11 @@ attributes:
     type: keyword
     constraint:
       enum:
-      - appx_I
-      - appx_II
-      - appx_III
-      - conditional
-      - NC  
+        - appx_I
+        - appx_II
+        - appx_III
+        - conditional
+        - NC
     value_metadata:
       appx_I:
         description: "CITES appendix I - globally threatened"
@@ -41,4 +41,3 @@ attributes:
         description: "CITES listed with specific conditions"
       NC:
         description: "Might not be CITES accepted - Check original source"
-        


### PR DESCRIPTION
The display group will be collating not only species listings, but also habitat information (e.g. WoRMS `is marine`). simplifying the display group name is less misleading.

## Summary by Sourcery

Rename the conservation-related display group from "conservation_status" to "conservation" across the conservation attribute definitions and normalize YAML formatting and indentation.