### PR TITLE
Add HUNTomics to auto-import

### DIFF
--- a/scripts/import_status.py
+++ b/scripts/import_status.py
@@ -22,6 +22,7 @@ projects = [
     "GAGA",
     "GBB",
     "GIGA",
+    "HUNTOMICS",
     "LOEWE-TBG",
     "OTHER",
     "PGP",

--- a/sources/assembly-data-sample/ATTR_assembly.types.yaml
+++ b/sources/assembly-data-sample/ATTR_assembly.types.yaml
@@ -85,6 +85,8 @@ attributes:
         description: "Genomics of Brazilian Biodiversity (click to view on ENA)"
       prjna649812:
         description: "Global Invertebrate Genomics Alliance (click to view on ENA)"
+      prjeb86906:
+        description: "HUNTomics Project genomics of huntable species in France (click to view on ENA)"
       prjna163993:
         description: "i5K (click to view on ENA)"
       prjna844590:

--- a/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
+++ b/sources/assembly-data-taxon/ncbi_datasets_eukaryota_taxon.types.yaml
@@ -52,6 +52,7 @@ attributes:
       PRJNA1180976: GBB
       PRJNA1075702: GBR
       PRJNA649812: GIGA
+      PRJEB86906: HUNTOMICS
       PRJNA163993: i5K
       PRJNA844590: ILEBP
       PRJNA1098055: IPM
@@ -114,6 +115,7 @@ attributes:
       PRJNA1180976: GBB
       PRJNA1075702: GBR
       PRJNA649812: GIGA
+      PRJEB86906: HUNTOMICS
       PRJNA163993: i5K
       PRJNA844590: ILEBP
       PRJNA1098055: IPM
@@ -399,6 +401,13 @@ attributes:
       - ;
     translate:
       PRJNA1075702: insdc_open
+  sequencing_status_huntomics:
+    display_group: sequencing_status
+    header: bioProjectAccession
+    separator:
+      - ;
+    translate:
+      PRJEB86906: insdc_open
   sequencing_status_i5k:
     display_group: sequencing_status
     header: bioProjectAccession

--- a/sources/assembly-data/ATTR_assembly.types.yaml
+++ b/sources/assembly-data/ATTR_assembly.types.yaml
@@ -113,6 +113,8 @@ attributes:
         description: "Genomics of the Brazilian Biodiversity (click to view on ENA)"
       prjna649812:
         description: "Global Invertebrate Genomics Alliance (click to view on ENA)"
+      prjeb86906:
+        description: "HUNTomics Project genomics of huntable species in France (click to view on ENA)"
       prjna163993:
         description: "i5K (click to view on ENA)"
       prjna844590:

--- a/sources/status-lists/ATTR_seq_status_project.types.yaml
+++ b/sources/status-lists/ATTR_seq_status_project.types.yaml
@@ -160,9 +160,9 @@ attributes:
   sequencing_status_giga:
     description: Sequencing status for Global Invertebrate Genome Alliance Project
     display_name: Sequencing status GIGA
-  sequencing_status_hk-ebp:
-    description: Sequencing status for Hong Kong EBP
-    display_name: Sequencing status HK-EBP
+  sequencing_status_huntomics:
+    description: Sequencing status for HUNTomics Project
+    display_name: Sequencing status HUNTOMICS
   sequencing_status_i5k:
     description: Sequencing status for 5,000 Insect Genomes Project
     display_name: Sequencing status i5K

--- a/sources/status-lists/ATTR_status_lists.types.yaml
+++ b/sources/status-lists/ATTR_status_lists.types.yaml
@@ -49,7 +49,7 @@ defaults:
         - gbb
         - gbr
         - giga
-        - hk-ebp
+        - huntomics
         - i5k
         - ilebp
         - ipm
@@ -153,8 +153,8 @@ defaults:
         description: "Great Barrier Reef SeaQuence Project (click to view GoaT project page)"
       giga:
         description: "Global Invertebrate Genomics Alliance (click to view GoaT project page)"
-      hk-ebp:
-        description: "Hong Kong EBP (click to view GoaT project page)"
+      huntomics:
+        description: "HUNTomics Project (click to view GoaT project page)"
       ffi:
         description: "Australian Functional Fungi Initiative (click to view GoaT project page)"
       fish:

--- a/sources/status-lists/ATTR_target_lists.types.yaml
+++ b/sources/status-lists/ATTR_target_lists.types.yaml
@@ -49,7 +49,7 @@ defaults:
         - gbb
         - gbr
         - giga
-        - hk-ebp
+        - huntomics
         - i5k
         - ilebp
         - ipm
@@ -153,8 +153,8 @@ defaults:
         description: "Great Barrier Reef SeaQuence Project (click to view GoaT project page)"
       giga:
         description: "Global Invertebrate Genomics Alliance (click to view GoaT project page)"
-      hk-ebp:
-        description: "Hong Kong EBP (click to view GoaT project page)"
+      huntomics:
+        description: "HUNTomics Project (click to view GoaT project page)"
       ffi:
         description: "Australian Functional Fungi Initiative (click to view GoaT project page)"
       fish:

--- a/sources/status-lists/FILE_HUNTomics.types.yaml
+++ b/sources/status-lists/FILE_HUNTomics.types.yaml
@@ -1,0 +1,51 @@
+file:
+  format: tsv
+  header: true
+  comment: "#"
+  name: HUNTOMICS_expanded.tsv
+  source: Declared Status List - HUNTOMICS
+  source_date: "2025-04-07"
+  source_description: HUNTOMICS Status List, live spreadsheet
+  source_contact: Pascal Lapébie and Carole Bodin, Fédération Nationale des Chasseurs - FNC
+attributes:
+  long_list:
+    header: long_list
+  other_priority:
+    header: other_priority
+  family_representative:
+    header: family_representative
+  # contributing_project_lab:
+  #   header: project
+  #   translate:
+  #     BGE: SSP Community Sampling
+  sequencing_status_huntomics:
+    header: sequencing_status
+    translate:
+      data_generation: in_progress
+      in_assembly: in_progress
+      insdc_submitted: in_progress
+  sequencing_status:
+    header: sequencing_status
+    translate:
+      data_generation: in_progress
+      in_assembly: in_progress
+      insdc_submitted: in_progress
+  sample_collected:
+    header: sample_collected
+  sample_acquired:
+    header: sample_acquired
+  in_progress:
+    header: in_progress
+  open:
+    header: open
+  insdc_open:
+    header: insdc_open
+  published:
+    header: published
+taxonomy:
+  taxon_id:
+    header: ncbi_taxon_id
+  species:
+    header: species
+  family:
+    header: family


### PR DESCRIPTION
Adresses #171

## Summary by Sourcery

Add HUNTomics as a new sequencing project across taxon, status list, and assembly configuration, and wire it into the status import pipeline.

New Features:
- Introduce HUNTomics project identifiers and sequencing status mapping in eukaryote taxon datasets.
- Register HUNTomics as a sequencing status and target list option with user-facing descriptions.
- Add ENA project description entries for the HUNTomics BioProject accession.
- Add a new HUNTOMICS status list file definition for importing project status from a TSV source.

Enhancements:
- Update status list defaults and descriptions to reference HUNTomics instead of the previous HK-EBP entry.
- Extend the import_status script to recognise HUNTOMICS as a valid project key.