### PR TITLE
Add AfricaBP to schema 2.6 daily workflow

### DIFF
--- a/scripts/import_status.py
+++ b/scripts/import_status.py
@@ -8,6 +8,7 @@ projects = [
     "959NG",
     "1000GCH",
     "AEGIS",
+    "AFRICABP",
     "ATLASEA",
     "BEENOME100",
     "CANBP",

--- a/sources/status-lists/FILE_AFRICABP_status.types.yaml
+++ b/sources/status-lists/FILE_AFRICABP_status.types.yaml
@@ -1,0 +1,55 @@
+file:
+  format: tsv
+  header: true
+  comment: "#"
+  name: AFRICABP_expanded.tsv
+  source: Declared Status List - AfricaBP
+  source_date: "2026-04-09"
+  source_description: AfricaBP Status List, live spreadsheet
+  source_contact: Bouabid Badaoui and ThankGod Ebenezer, AfricaBP
+attributes:
+  long_list:
+    header: long_list
+  other_priority:
+    header: other_priority
+  family_representative:
+    header: family_representative
+  # contributing_project_lab:
+  #   header: contributing_project_lab
+  #   separator:
+  #     - ","
+  #     - ";"
+  #   translate:
+  #     African BioGenome Project (AfricaBP): ""
+  #     " Nigeria": ""
+  sequencing_status_africabp:
+    header: sequencing_status
+    translate:
+      data_generation: in_progress
+      in_assembly: in_progress
+      insdc_submitted: in_progress
+  sequencing_status:
+    header: sequencing_status
+    translate:
+      data_generation: in_progress
+      in_assembly: in_progress
+      insdc_submitted: in_progress
+  sample_collected:
+    header: sample_collected
+  sample_acquired:
+    header: sample_acquired
+  in_progress:
+    header: in_progress
+  open:
+    header: open
+  insdc_open:
+    header: insdc_open
+  published:
+    header: published
+taxonomy:
+  taxon_id:
+    header: ncbi_taxon_id
+  species:
+    header: species
+  family:
+    header: family


### PR DESCRIPTION
addresses #174

## Summary by Sourcery

Add AfricaBP as a supported project in the daily import status workflow for schema 2.6.

New Features:
- Add AfricaBP to the list of projects handled by the import status script.
- Introduce a status type configuration file for AfricaBP source data.