### PR TITLE
Restore config files

### DIFF
--- a/sources/assembly-data-sample/ATTR_assembly.types.yaml
+++ b/sources/assembly-data-sample/ATTR_assembly.types.yaml
@@ -86,7 +86,7 @@ attributes:
       prjna649812:
         description: "Global Invertebrate Genomics Alliance (click to view on ENA)"
       prjeb86906:
-        description: "HUNTomics Project genomics of huntable species in France (click to view on ENA)"
+        description: "HUNTomics Project (click to view on ENA)"
       prjna163993:
         description: "i5K (click to view on ENA)"
       prjna844590:

--- a/sources/status-lists/ATTR_seq_status_project.types.yaml
+++ b/sources/status-lists/ATTR_seq_status_project.types.yaml
@@ -160,9 +160,9 @@ attributes:
   sequencing_status_giga:
     description: Sequencing status for Global Invertebrate Genome Alliance Project
     display_name: Sequencing status GIGA
-  sequencing_status_hk-ebp:
-    description: Sequencing status for Hong Kong EBP
-    display_name: Sequencing status HK-EBP
+  sequencing_status_huntomics:
+    description: Sequencing status for HUNTomics Project
+    display_name: Sequencing status HUNTOMICS
   sequencing_status_i5k:
     description: Sequencing status for 5,000 Insect Genomes Project
     display_name: Sequencing status i5K

--- a/sources/status-lists/ATTR_status_lists.types.yaml
+++ b/sources/status-lists/ATTR_status_lists.types.yaml
@@ -49,7 +49,7 @@ defaults:
         - gbb
         - gbr
         - giga
-        - hk-ebp
+        - huntomics
         - i5k
         - ilebp
         - ipm
@@ -153,8 +153,8 @@ defaults:
         description: "Great Barrier Reef SeaQuence Project (click to view GoaT project page)"
       giga:
         description: "Global Invertebrate Genomics Alliance (click to view GoaT project page)"
-      hk-ebp:
-        description: "Hong Kong EBP (click to view GoaT project page)"
+      huntomics:
+        description: "HUNTomics Project (click to view GoaT project page)"
       ffi:
         description: "Australian Functional Fungi Initiative (click to view GoaT project page)"
       fish:

--- a/sources/status-lists/ATTR_target_lists.types.yaml
+++ b/sources/status-lists/ATTR_target_lists.types.yaml
@@ -49,7 +49,7 @@ defaults:
         - gbb
         - gbr
         - giga
-        - hk-ebp
+        - huntomics
         - i5k
         - ilebp
         - ipm
@@ -153,8 +153,8 @@ defaults:
         description: "Great Barrier Reef SeaQuence Project (click to view GoaT project page)"
       giga:
         description: "Global Invertebrate Genomics Alliance (click to view GoaT project page)"
-      hk-ebp:
-        description: "Hong Kong EBP (click to view GoaT project page)"
+      huntomics:
+        description: "HUNTomics Project (click to view GoaT project page)"
       ffi:
         description: "Australian Functional Fungi Initiative (click to view GoaT project page)"
       fish:


### PR DESCRIPTION
Because there were outdated configuration files on S3 resoures, the GoaT import has reverted files in main. 

This uses the latest updated configs from status-lists. The idea is to check the behaviour of import tomorrow for HUNTomics but I need to assess the best/standard operation procedures for target list updates, which is likely to continue adding configuration files to S3 but ensure those are removed after successful imports.

## Summary by Sourcery

Update configuration status and target list metadata to use the current HUNTomics project naming instead of the deprecated HK-EBP variant.

Enhancements:
- Align sequencing status attributes and display names with the HUNTomics project terminology.
- Refresh project key lists and descriptions in status and target list configs to reference HUNTomics.
- Simplify the HUNTomics ENA project description in the assembly attribute sample configuration.