### PR TITLE
Add subprojects field to AfricaBP import

### DIFF
--- a/sources/status-lists/FILE_AFRICABP_status.types.yaml
+++ b/sources/status-lists/FILE_AFRICABP_status.types.yaml
@@ -14,14 +14,12 @@ attributes:
     header: other_priority
   family_representative:
     header: family_representative
-  # contributing_project_lab:
-  #   header: contributing_project_lab
-  #   separator:
-  #     - ","
-  #     - ";"
-  #   translate:
-  #     African BioGenome Project (AfricaBP): ""
-  #     " Nigeria": ""
+  contributing_project_lab:
+    header: contributing_project_lab
+    separator:
+      - ";"
+    translate:
+      " Nigeria": ""
   sequencing_status_africabp:
     header: sequencing_status
     translate:


### PR DESCRIPTION
removes comment of contributing_project_lab field from config

## Summary by Sourcery

Enhancements:
- Adjust contributing_project_lab parsing by enabling it with a semicolon separator and simplified translation mapping in the AfricaBP import configuration.