### PR TITLE
Set null values for Red List indexing and shorten descriptions

### DIFF
--- a/.github/workflows/genomehubs-index.yml
+++ b/.github/workflows/genomehubs-index.yml
@@ -133,7 +133,7 @@ jobs:
           release: ${{ inputs.release }}
           resources: ${{ inputs.resources }}
           directory: conservation
-          flags: --taxon-lookup any --taxon-spellcheck
+          flags: --taxon-lookup any --taxon-spellcheck --blank "N/A" --blank "None"
           type: taxon
       - name: Index uk-legislation
         uses: ./.github/workflows/genomehubs-index-directory

--- a/sources/conservation/ATTR_conservation.types.yaml
+++ b/sources/conservation/ATTR_conservation.types.yaml
@@ -54,46 +54,48 @@ attributes:
     type: keyword
     constraint:
       enum:
-        - 'NT'
-        - 'CR'
-        - 'EN'
-        - 'DD'
-        - 'VU'
-        - 'LC'
-        - 'EX'
-        - 'EW'
-        - 'not_applicable'
-        - 'RE'
-        - 'LR-nt'
-        - 'LR-lc'
-        - 'LR-cd'
+        - "NT"
+        - "CR"
+        - "EN"
+        - "DD"
+        - "VU"
+        - "LC"
+        - "EX"
+        - "EW"
+        - "NA"
+        - "RE"
+        - "LR-nt"
+        - "LR-lc"
+        - "LR-cd"
     value_metadata:
-      'NT':
-        description: "Near Threatened - Species is close to qualifying for or is likely to qualify for a threatened category in the near future."
-      'CR':
-        description: "Critically Endangered - Species is facing an extremely high risk of extinction in the wild."
-      'EN':
-        description: "Endangered - Species is facing a very high risk of extinction in the wild."
-      'DD':
-        description: "Data Deficient - Insufficient information to make a direct, or indirect, assessment of its risk of extinction based on its distribution and or population status."
-      'VU':
-        description: "Vulnerable - Species is considered as facing a high risk of extinction in the wild."
-      'LC':
-        description: "Least Concern - Species is evaluated against the Red List criteria, but does not qualify for any category of threat."
-      'EX':
-        description: "Extinct - No reasonable doubt that the last individual has died."
-      'EW':
-        description: "Extinct in the Wild - Known only to survive in cultivation, in captivity, or as a naturalized population outside its historic range."
-      'not_applicable':
+      default:
+        description: "IUCN Red List category of the taxon in the latest assessment."
+      NT:
+        description: "Near Threatened"
+      CR:
+        description: "Critically Endangered"
+      EN:
+        description: "Endangered"
+      DD:
+        description: "Data Deficient"
+      VU:
+        description: "Vulnerable"
+      LC:
+        description: "Least Concern"
+      EX:
+        description: "Extinct"
+      EW:
+        description: "Extinct in the Wild"
+      NA:
         description: "Category not applicable."
-      'RE':
-        description: "Regionally Extinct - Species is extinct in a specific region but occurs in its natural range elsewhere."
-      'LR-nt':
-        description: "Lower Risk-near threatened - Species is close to qualifying for a threatened category in the near future."
-      'LR-lc':
-        description: "Lower Risk-least concern - Species is evaluated but does not qualify for any category of threat."
-      'LR-cd':
-        description: "Lower Risk-conservation dependent - Species is the focus of a conservation program, the cessation of which would result in it qualifying for a threatened category within a period of five years."
+      RE:
+        description: "Regionally Extinct"
+      LR-nt:
+        description: "Lower Risk-near threatened"
+      LR-lc:
+        description: "Lower Risk-least concern"
+      LR-cd:
+        description: "Lower Risk-conservation dependent"
   redlist_scopes:
     description: IUCN Red List threat status category scope.
     long_description: The region scope under which the threat assessment was made

--- a/sources/conservation/FILE_RedList_species.types.yaml
+++ b/sources/conservation/FILE_RedList_species.types.yaml
@@ -21,7 +21,7 @@ attributes:
       Least Concern: LC
       Extinct: EX
       Extinct in the Wild: EW
-      Not Applicable: not_applicable
+      Not Applicable: NA
       Regionally Extinct: RE
       Lower Risk/near threatened: LR-nt
       Lower Risk/least concern: LR-lc


### PR DESCRIPTION
This should fix:
-  NA being captured as a null value
- The descriptions not showing in the tooltip

## Summary by Sourcery

Update IUCN Red List category handling and indexing configuration for conservation data.

New Features:
- Add explicit handling of 'NA' as a valid IUCN Red List category value with associated metadata.
- Treat common blank placeholders ('N/A' and 'None') as null values during conservation indexing.

Enhancements:
- Shorten and standardize IUCN Red List category descriptions for tooltips and add a generic default description.