### PR TITLE
change constraint-enum for the vgp data freeze

### DIFF
--- a/sources/assembly-data/ATTR_assembly.types.yaml
+++ b/sources/assembly-data/ATTR_assembly.types.yaml
@@ -476,11 +476,14 @@ attributes:
     constraint:
       enum:
         - latest
-        - vgp_phase1_main
-        - vgp_phase1_comp_vgp
-        - vgp_phase1_alt
-        - vgp_phase1_aux
-        - vgp_phase1_comp_external
+        - vgp_phase1_main_v1
+        - vgp_phase1_main_v4
+        - vgp_phase1_main_ucsc
+        - vgp_phase1_busco_vgp
+        - vgp_phase1_comp_busco_external
+        - vgp_phase1_comp_busco_vgp
+        - vgp_phase1_alignment
+        - vgp_phase1_external
     description: list of data freezes this assembly is included in
     display_group: data_freeze
     type: keyword


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace legacy VGP phase 1 data-freeze enum values with the new set of phase 1 freeze identifiers in the assembly attribute schema.