### PR TITLE
fix cat in API and UI tests for release workflow

### DIFF
--- a/tests/api/generic/ebp-rainbow.yaml
+++ b/tests/api/generic/ebp-rainbow.yaml
@@ -1,6 +1,6 @@
 description: Check EBP progress rainbow
 endpoint: report
-querystring: report=arc&x=assembly_span%20AND%20bioproject%3DPRJNA533106&rank=phylum%2Cclass%2Corder%2Cfamily%2Cgenus%2Cspecies&includeEstimates=true&excludeAncestral%5B0%5D=bioproject&excludeMissing%5B0%5D=bioproject&taxonomy=ncbi&result=taxon
+querystring: report=arc&x=assembly_span%20AND%20assembly_level%20AND%20bioproject%3DPRJNA533106&rank=phylum%2Cclass%2Corder%2Cfamily%2Cgenus%2Cspecies&includeEstimates=true&excludeAncestral%5B0%5D=bioproject&excludeMissing%5B0%5D=bioproject&taxonomy=ncbi&result=taxon
 assert:
   status:
     success: true

--- a/tests/api/generic/ebp-species-2023.yaml
+++ b/tests/api/generic/ebp-species-2023.yaml
@@ -1,6 +1,6 @@
 description: Check EBP species by time plot
 endpoint: report
-querystring: report=histogram&rank=species&result=taxon&cat=assembly_level%3Dcontig%2Cscaffold%2Cchromosome%2Ccomplete%20genome&includeEstimates=true&excludeAncestral%5B0%5D=bioproject&excludeMissing%5B0%5D=bioproject&stacked=true&cumulative=true&xOpts=2006%2C%2C2%2C%2CAssembly%20date&taxonomy=ncbi&x=min%28assembly_date%29%20AND%20bioproject%3DPRJNA533106
+querystring: report=histogram&rank=species&result=taxon&cat=assembly_level%3Dcontig%2Cscaffold%2Cchromosome%2Ccomplete%20genome&includeEstimates=true&excludeAncestral%5B0%5D=bioproject&excludeMissing%5B0%5D=bioproject&stacked=true&cumulative=true&xOpts=2006%2C%2C2%2C%2CAssembly%20date&taxonomy=ncbi&x=min%28assembly_date%29%20AND%20bioproject%3DPRJNA533106%20AND%20assembly_level
 assert:
   status:
     success: true

--- a/tests/ui/Psyche/config.yaml
+++ b/tests/ui/Psyche/config.yaml
@@ -1,8 +1,8 @@
 - url: "http://localhost:8880/search?report=arc&query=sample_collected%3DDTOL&y=long_list%3DPSYCHE&rank=species&includeEstimates=true&excludeAncestral%5b0%5d=sample_collected&excludeMissing%5b0%5d=sample_collected&taxonomy=ncbi&result=taxon&pointSize=15"
   filename: target-species-collected.png
-- url: "http://localhost:8880/search?report=arc&query=assembly_span%20AND%20bioproject%3DPRJEB40665&rank=family%2Cgenus%2Cspecies&y=long_list%3DPSYCHE&includeEstimates=true&excludeAncestral%5B0%5D=assembly_span&excludeMissing%5B0%5D=assembly_span&taxonomy=ncbi&result=taxon&xField=assembly_span&pointSize=15"
+- url: "http://localhost:8880/search?report=arc&query=assembly_span%20AND%20bioproject%3DPRJEB40665%20AND%20assembly_level&rank=family%2Cgenus%2Cspecies&y=long_list%3DPSYCHE&includeEstimates=true&excludeAncestral%5B0%5D=assembly_span&excludeMissing%5B0%5D=assembly_span&taxonomy=ncbi&result=taxon&xField=assembly_span&pointSize=15"
   filename: assemblies-by-rank.png
-- url: "http://localhost:8880/search?result=taxon&includeEstimates=true&summaryValues=count&taxonomy=ncbi&size=10&offset=0&report=histogram&rank=species&pointSize=15&query=tax_tree%28lepidoptera%29%20AND%20min%28assembly_date%29%3E2023%20AND%20bioproject%3DPRJEB40665%20AND%20tax_rank%28species%29&cat=assembly_level&stacked=true&xOpts=2023-03%2C2024%2C%2C%2CAssembly%20date%20%28month%29"
+- url: "http://localhost:8880/search?result=taxon&includeEstimates=true&summaryValues=count&taxonomy=ncbi&size=10&offset=0&report=histogram&rank=species&pointSize=15&query=tax_tree%28lepidoptera%29%20AND%20min%28assembly_date%29%3E2023%20AND%20bioproject%3DPRJEB40665%20AND%20tax_rank%28species%29%20AND%20assembly_level&cat=assembly_level&stacked=true&xOpts=2023-03%2C2024%2C%2C%2CAssembly%20date%20%28month%29"
   filename: progress-per-month.png
 - url: "http://localhost:8880/search?report=tree&query=tax_tree%28Eukaryota%29%20AND%20tax_rank%28family%29%20AND%20long_list%3DPSYCHE&y=assembly_span%20AND%20bioproject%3DTBD&treeStyle=rect&levels=subspecies%2Cspecies%2Cgenus%2Cfamily%2Corder%2Cclass%2Cphylum&includeEstimates=true&collapseMonotypic=true&yOpts=10000000%2C7000000000%2C%2Clog10&taxonomy=ncbi&result=taxon"
   filename: sequenced-family-cladogram.png
@@ -12,7 +12,7 @@
 - url: "http://localhost:8880/search?report=arc&query=assembly_span%20AND%20bioproject%3DPRJEB40665&rank=family%2Cgenus%2Cspecies&y=long_list%3DPSYCHE&includeEstimates=true&excludeAncestral%5B0%5D=assembly_span&excludeMissing%5B0%5D=assembly_span&taxonomy=ncbi&result=taxon&xField=assembly_span&pointSize=15"
   filename: assemblies-by-rank-2000.png
   size: 2000
-- url: "http://localhost:8880/search?result=taxon&includeEstimates=true&summaryValues=count&taxonomy=ncbi&size=10&offset=0&report=histogram&rank=species&pointSize=15&query=tax_tree%28lepidoptera%29%20AND%20min%28assembly_date%29%3E2023%20AND%20bioproject%3DPRJEB40665%20AND%20tax_rank%28species%29&cat=assembly_level&stacked=true&xOpts=2023-03%2C2024%2C%2C%2CAssembly%20date%20%28month%29"
+- url: "http://localhost:8880/search?result=taxon&includeEstimates=true&summaryValues=count&taxonomy=ncbi&size=10&offset=0&report=histogram&rank=species&pointSize=15&query=tax_tree%28lepidoptera%29%20AND%20min%28assembly_date%29%3E2023%20AND%20bioproject%3DPRJEB40665%20AND%20assembly_level%20AND%20tax_rank%28species%29&cat=assembly_level&stacked=true&xOpts=2023-03%2C2024%2C%2C%2CAssembly%20date%20%28month%29"
   filename: progress-per-month-2000.png
   size: 2000
 - url: "http://localhost:8880/search?report=tree&query=tax_tree%28Eukaryota%29%20AND%20tax_rank%28family%29%20AND%20long_list%3DPSYCHE&y=assembly_span%20AND%20bioproject%3DTBD&treeStyle=rect&levels=subspecies%2Cspecies%2Cgenus%2Cfamily%2Corder%2Cclass%2Cphylum&includeEstimates=true&collapseMonotypic=true&yOpts=10000000%2C7000000000%2C%2Clog10&taxonomy=ncbi&result=taxon"


### PR DESCRIPTION
Fix applied to histogram categories caused a bug where date histograms need specification of "assembly_level" when it is used as categories. The underlying data issue is the presence of organellar metadata in the  field for assembly_span in the absence of a genome assembly. 

To allow test histograms I have added `assembly_level` to the query of test reports.

## Summary by Sourcery

Ensure histogram and arc report tests explicitly filter on assembly_level to avoid invalid organellar metadata affecting results

Bug Fixes:
- Add assembly_level filters to Psyche UI histogram and arc report URLs to restore valid test histograms
- Include assembly_level in EBP API report queries so histogram categories resolve correctly in automated tests

Tests:
- Update UI and API test configurations to require assembly_level when assembly_span or assembly_level-based histogram categories are used